### PR TITLE
Remove `return_stored` from public API for `compute` and `to_zarr` 

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -106,7 +106,6 @@ class CoreArray:
     def compute(
         self,
         *,
-        return_stored=True,
         executor=None,
         callbacks=None,
         optimize_graph=True,
@@ -115,13 +114,12 @@ class CoreArray:
         """Compute this array, and any arrays that it depends on."""
         result = compute(
             self,
-            return_stored=return_stored,
             executor=executor,
             callbacks=callbacks,
             optimize_graph=optimize_graph,
             **kwargs,
         )
-        if return_stored:
+        if result:
             return result[0]
 
     def rechunk(self, chunks):
@@ -269,7 +267,6 @@ def check_array_specs(arrays):
 
 def compute(
     *arrays,
-    return_stored=True,
     executor=None,
     callbacks=None,
     optimize_graph=True,
@@ -282,6 +279,7 @@ def compute(
         if executor is None:
             executor = PythonPipelineExecutor()
 
+    _return_in_memory_array = kwargs.pop("_return_in_memory_array", True)
     execute_dag(
         dag,
         executor=executor,
@@ -290,7 +288,7 @@ def compute(
         **kwargs,
     )
 
-    if return_stored:
+    if _return_in_memory_array:
         return tuple(a._read_stored() for a in arrays)
 
 

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -89,7 +89,7 @@ def from_zarr(store, spec=None):
     return CoreArray._new(name, target, spec, plan)
 
 
-def to_zarr(x, store, return_stored=False, executor=None):
+def to_zarr(x, store, executor=None, **kwargs):
     """Save an array to Zarr storage.
 
     Note that this operation is eager, and will run the computation
@@ -101,9 +101,6 @@ def to_zarr(x, store, return_stored=False, executor=None):
         Array to save
     store : string
         Path to output Zarr store
-    return_stored : bool, optional
-        Whether to return the array as a NumPy array.
-        (False by default.)
     executor : cubed.runtime.types.Executor, optional
         The executor to use to run the computation.
         Defaults to using the in-process Python executor.
@@ -115,7 +112,7 @@ def to_zarr(x, store, return_stored=False, executor=None):
     out = blockwise(
         identity, ind, x, ind, dtype=x.dtype, align_arrays=False, target_store=store
     )
-    return out.compute(return_stored=return_stored, executor=executor)
+    return out.compute(executor=executor, _return_in_memory_array=False, **kwargs)
 
 
 def blockwise(

--- a/examples/dataflow-add-random.py
+++ b/examples/dataflow-add-random.py
@@ -29,7 +29,8 @@ def run(argv=None):
         (50000, 50000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.add(a, b)
-    c.compute(return_stored=False, executor=executor, options=beam_options)
+    # use store=None to write to temporary zarr
+    cubed.to_zarr(c, store=None, executor=executor, options=beam_options)
 
 
 if __name__ == "__main__":

--- a/examples/dataflow-matmul-random.py
+++ b/examples/dataflow-matmul-random.py
@@ -31,7 +31,8 @@ def run(argv=None):
     c = xp.astype(a, xp.float32)
     d = xp.astype(b, xp.float32)
     e = xp.matmul(c, d)
-    e.compute(return_stored=False, executor=executor, options=beam_options)
+    # use store=None to write to temporary zarr
+    cubed.to_zarr(e, store=None, executor=executor, options=beam_options)
 
 
 if __name__ == "__main__":

--- a/examples/lithops-add-random.py
+++ b/examples/lithops-add-random.py
@@ -32,8 +32,10 @@ if __name__ == "__main__":
         progress = TqdmProgressBar()
         hist = HistoryCallback()
         timeline_viz = TimelineVisualizationCallback()
-        c.compute(
-            return_stored=False,
+        # use store=None to write to temporary zarr
+        cubed.to_zarr(
+            c,
+            store=None,
             executor=executor,
             callbacks=[progress, hist, timeline_viz],
             runtime=runtime,

--- a/examples/lithops-matmul-random.py
+++ b/examples/lithops-matmul-random.py
@@ -35,8 +35,10 @@ if __name__ == "__main__":
         progress = TqdmProgressBar()
         hist = HistoryCallback()
         timeline_viz = TimelineVisualizationCallback()
-        e.compute(
-            return_stored=False,
+        # use store=None to write to temporary zarr
+        cubed.to_zarr(
+            e,
+            store=None,
             executor=executor,
             callbacks=[progress, hist, timeline_viz],
             runtime=runtime,

--- a/examples/modal-add-random.py
+++ b/examples/modal-add-random.py
@@ -20,4 +20,5 @@ if __name__ == "__main__":
     c = xp.add(a, b)
     hist = HistoryCallback()
     timeline_viz = TimelineVisualizationCallback()
-    c.compute(return_stored=False, executor=executor, callbacks=[timeline_viz, hist])
+    # use store=None to write to temporary zarr
+    cubed.to_zarr(c, store=None, executor=executor, callbacks=[timeline_viz, hist])

--- a/examples/modal-matmul-random.py
+++ b/examples/modal-matmul-random.py
@@ -25,8 +25,7 @@ if __name__ == "__main__":
         progress = TqdmProgressBar(file=orig_stdout, dynamic_ncols=True)
         hist = HistoryCallback()
         timeline_viz = TimelineVisualizationCallback()
-        e.compute(
-            return_stored=False,
-            executor=executor,
-            callbacks=[progress, hist, timeline_viz],
+        # use store=None to write to temporary zarr
+        cubed.to_zarr(
+            e, store=None, executor=executor, callbacks=[progress, hist, timeline_viz]
         )


### PR DESCRIPTION
... since it had a different meaning to the same keyword in Dask.