### PR TITLE
Expose Array not CoreArray

### DIFF
--- a/cubed/__init__.py
+++ b/cubed/__init__.py
@@ -12,25 +12,28 @@ try:
 except Exception:  # pragma: no cover
     __version__ = "unknown"
 
-from .core import (
+from .array_api import Array
+from .core.array import (
     Callback,
-    CoreArray,
     Spec,
     TaskEndEvent,
     compute,
+    measure_baseline_memory,
+    visualize,
+)
+from .core.ops import (
     from_array,
     from_zarr,
     map_blocks,
-    measure_baseline_memory,
     store,
     to_zarr,
-    visualize,
 )
+
 
 __all__ = [
     "__version__",
     "Callback",
-    "CoreArray",
+    "Array",
     "Spec",
     "TaskEndEvent",
     "compute",

--- a/cubed/array_api/__init__.py
+++ b/cubed/array_api/__init__.py
@@ -1,5 +1,9 @@
 __all__ = []
 
+from .array_object import Array
+
+__all__ += ["Array"]
+
 from .constants import e, inf, nan, newaxis, pi
 
 __all__ += ["e", "inf", "nan", "newaxis", "pi"]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,10 +13,10 @@ Creation Functions.
     :nosignatures:
     :toctree: generated/
 
-    CoreArray
-    CoreArray.compute
-    CoreArray.rechunk
-    CoreArray.visualize
+    Array
+    Array.compute
+    Array.rechunk
+    Array.visualize
     compute
     visualize
 


### PR DESCRIPTION
Closes #123.

Most of the changes are either fixing a circular dependency (where `cubed.core.ops` now imports `cubed.array_api.Array`, which imports the ops again), or writing down some type hints.

I can add isinstance checks in tests if you want.

The type hints don't do anything yet, especially as there is no pre-commit or CI setup. I can add that and start gradually typing the codebase if you want too?
