### PR TITLE
Reserved memory

### DIFF
--- a/cubed/__init__.py
+++ b/cubed/__init__.py
@@ -18,7 +18,7 @@ from .core.array import (
     Spec,
     TaskEndEvent,
     compute,
-    measure_baseline_memory,
+    measure_reserved_memory,
     visualize,
 )
 from .core.ops import (
@@ -40,7 +40,7 @@ __all__ = [
     "from_array",
     "from_zarr",
     "map_blocks",
-    "measure_baseline_memory",
+    "measure_reserved_memory",
     "store",
     "to_zarr",
     "visualize",

--- a/cubed/core/__init__.py
+++ b/cubed/core/__init__.py
@@ -6,7 +6,7 @@ from .array import (
     TaskEndEvent,
     compute,
     gensym,
-    measure_baseline_memory,
+    measure_reserved_memory,
     visualize,
 )
 from .ops import (

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -190,10 +190,17 @@ class CoreArray:
 class Spec:
     """Specification of resources available to run a computation."""
 
-    work_dir: str
-    max_mem: int
+    work_dir: Optional[str] = None
+    """The directory path (specified as an fsspec URL) used for storing intermediate data."""
+
+    max_mem: Optional[int] = None
+    """The maximum memory available to a worker for data use for the computation."""
+
     executor: Executor = None
+    """The default executor for running computations."""
+
     storage_options: dict = None
+    """Storage options to be passed to fsspec"""
 
 
 class Callback:
@@ -325,8 +332,18 @@ class PeakMemoryCallback(Callback):
         self.peak_memory = event.peak_memory_end
 
 
-def measure_baseline_memory(executor):
-    """Measures the baseline memory use for a given executor runtime.
+def measure_reserved_memory(executor):
+    """Measures the reserved memory use for a given executor runtime.
+
+    This is the memory used by the Python process for running a task,
+    excluding any memory used for data for the computation. It can vary by
+    operating system, Python version, executor runtime, and installed package
+    versions.
+
+    It can be used as a guide to set ``reserved_mem`` when creating a ``Spec`` object.
+
+    This implementation works by running a trivial computation on a tiny amount of
+    data and measuring the peak memory use.
 
     Parameters
     ----------

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -38,8 +38,9 @@ class CoreArray:
         self._chunks = normalize_chunks(
             zarray.chunks, shape=self.shape, dtype=self.dtype
         )
-        # if no spec is supplied, use a default with local temp dir, and a modest amount of memory (100MB)
-        self.spec = spec or Spec(None, 100_000_000)
+        # if no spec is supplied, use a default with local temp dir, a modest amount of memory (100MB),
+        # and a conservative amount of reserved memory (200MB)
+        self.spec = spec or Spec(None, max_mem=100_000_000, reserved_mem=200_000_000)
         self.plan = plan
 
     @classmethod
@@ -194,7 +195,15 @@ class Spec:
     """The directory path (specified as an fsspec URL) used for storing intermediate data."""
 
     max_mem: Optional[int] = None
-    """The maximum memory available to a worker for data use for the computation."""
+    """The maximum memory available to a worker for data use for the computation, in bytes."""
+
+    reserved_mem: Optional[int] = None
+    """The memory reserved on a worker for non-data use, in bytes.
+
+    The sum of ``max_mem`` and ``reserved_mem`` should not exceed the total memory of the worker.
+
+    See ``cubed.measure_reserved_memory``.
+    """
 
     executor: Executor = None
     """The default executor for running computations."""

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -509,11 +509,11 @@ def test_no_fusion_multiple_edges(spec):
     assert_array_equal(result, np.full((2, 2), True))
 
 
-def test_measure_baseline_memory(executor):
+def test_measure_reserved_memory(executor):
     from cubed.runtime.executors.lithops import LithopsDagExecutor
 
     if not isinstance(executor, LithopsDagExecutor):
-        pytest.skip(f"{type(executor)} does not support measure_baseline_memory")
+        pytest.skip(f"{type(executor)} does not support measure_reserved_memory")
 
-    baseline_memory = cubed.measure_baseline_memory(executor=executor)
-    assert baseline_memory > 1_000_000  # over 1MB
+    reserved_memory = cubed.measure_reserved_memory(executor=executor)
+    assert reserved_memory > 1_000_000  # over 1MB

--- a/cubed/tests/test_mem_utilization.py
+++ b/cubed/tests/test_mem_utilization.py
@@ -17,46 +17,46 @@ def spec(tmp_path):
 
 
 @pytest.fixture()
-def baseline_mem():
+def reserved_mem():
     executor = LithopsDagExecutor(config=LITHOPS_LOCAL_CONFIG)
-    return cubed.measure_baseline_memory(executor)
+    return cubed.measure_reserved_memory(executor)
 
 
 # Array Object
 
 
 @pytest.mark.slow
-def test_index(spec, baseline_mem):
+def test_index(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = a[1:, :]
-    run_operation("index", b, baseline_mem)
+    run_operation("index", b, reserved_mem)
 
 
 # Creation Functions
 
 
 @pytest.mark.slow
-def test_eye(spec, baseline_mem):
+def test_eye(spec, reserved_mem):
     a = xp.eye(10000, 10000, chunks=(5000, 5000), spec=spec)
-    run_operation("eye", a, baseline_mem)
+    run_operation("eye", a, reserved_mem)
 
 
 @pytest.mark.slow
-def test_tril(spec, baseline_mem):
+def test_tril(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.tril(a)
-    run_operation("tril", b, baseline_mem)
+    run_operation("tril", b, reserved_mem)
 
 
 # Elementwise Functions
 
 
 @pytest.mark.slow
-def test_add(spec, baseline_mem):
+def test_add(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -64,23 +64,23 @@ def test_add(spec, baseline_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.add(a, b)
-    run_operation("add", c, baseline_mem)
+    run_operation("add", c, reserved_mem)
 
 
 @pytest.mark.slow
-def test_negative(spec, baseline_mem):
+def test_negative(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.negative(a)
-    run_operation("negative", b, baseline_mem)
+    run_operation("negative", b, reserved_mem)
 
 
 # Linear Algebra Functions
 
 
 @pytest.mark.slow
-def test_matmul(spec, baseline_mem):
+def test_matmul(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -90,20 +90,20 @@ def test_matmul(spec, baseline_mem):
     c = xp.astype(a, xp.float32)
     d = xp.astype(b, xp.float32)
     e = xp.matmul(c, d)
-    run_operation("matmul", e, baseline_mem)
+    run_operation("matmul", e, reserved_mem)
 
 
 @pytest.mark.slow
-def test_matrix_transpose(spec, baseline_mem):
+def test_matrix_transpose(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.matrix_transpose(a)
-    run_operation("matrix_transpose", b, baseline_mem)
+    run_operation("matrix_transpose", b, reserved_mem)
 
 
 @pytest.mark.slow
-def test_tensordot(spec, baseline_mem):
+def test_tensordot(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -113,14 +113,14 @@ def test_tensordot(spec, baseline_mem):
     c = xp.astype(a, xp.float32)
     d = xp.astype(b, xp.float32)
     e = xp.tensordot(c, d, axes=1)
-    run_operation("tensordot", e, baseline_mem)
+    run_operation("tensordot", e, reserved_mem)
 
 
 # Manipulation Functions
 
 
 @pytest.mark.slow
-def test_concat(spec, baseline_mem):
+def test_concat(spec, reserved_mem):
     # Note 'a' has one fewer element in axis=0 to force chunking to cross array boundaries
     a = cubed.random.random(
         (9999, 10000), chunks=(5000, 5000), spec=spec
@@ -129,22 +129,22 @@ def test_concat(spec, baseline_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.concat((a, b), axis=0)
-    run_operation("concat", c, baseline_mem)
+    run_operation("concat", c, reserved_mem)
 
 
 @pytest.mark.slow
-def test_reshape(spec, baseline_mem):
+def test_reshape(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     # need intermediate reshape due to limitations in Dask's reshape_rechunk
     b = xp.reshape(a, (5000, 2, 10000))
     c = xp.reshape(b, (5000, 20000))
-    run_operation("reshape", c, baseline_mem)
+    run_operation("reshape", c, reserved_mem)
 
 
 @pytest.mark.slow
-def test_stack(spec, baseline_mem):
+def test_stack(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -152,46 +152,46 @@ def test_stack(spec, baseline_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.stack((a, b), axis=0)
-    run_operation("stack", c, baseline_mem)
+    run_operation("stack", c, reserved_mem)
 
 
 # Searching Functions
 
 
 @pytest.mark.slow
-def test_argmax(spec, baseline_mem):
+def test_argmax(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.argmax(a, axis=0)
-    run_operation("argmax", b, baseline_mem)
+    run_operation("argmax", b, reserved_mem)
 
 
 # Statistical Functions
 
 
 @pytest.mark.slow
-def test_max(spec, baseline_mem):
+def test_max(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.max(a, axis=0)
-    run_operation("max", b, baseline_mem)
+    run_operation("max", b, reserved_mem)
 
 
 @pytest.mark.slow
-def test_mean(spec, baseline_mem):
+def test_mean(spec, reserved_mem):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.mean(a, axis=0)
-    run_operation("mean", b, baseline_mem)
+    run_operation("mean", b, reserved_mem)
 
 
 # Internal functions
 
 
-def run_operation(name, result_array, baseline_mem):
+def run_operation(name, result_array, reserved_mem):
     # result_array.visualize(f"cubed-{name}-unoptimized", optimize_graph=False)
     # result_array.visualize(f"cubed-{name}")
     executor = LithopsDagExecutor(config=LITHOPS_LOCAL_CONFIG)
@@ -201,21 +201,21 @@ def run_operation(name, result_array, baseline_mem):
 
     plan_df = pd.read_csv(hist.plan_df_path)
     stats_df = pd.read_csv(hist.stats_df_path)
-    df = analyze(plan_df, stats_df, baseline_mem)
+    df = analyze(plan_df, stats_df, reserved_mem)
     print(df)
 
     # check utilization does not exceed 1
     assert (df["utilization"] <= 1.0).all()
 
 
-def analyze(plan_df, stats_df, baseline_mem):
+def analyze(plan_df, stats_df, reserved_mem):
 
-    baseline_mem_mb = baseline_mem / 1_000_000
-    baseline_mem_mb *= 1.05  # add some wiggle room
+    reserved_mem_mb = reserved_mem / 1_000_000
+    reserved_mem_mb *= 1.05  # add some wiggle room
 
     # convert memory to MB
     plan_df["required_mem_mb"] = plan_df["required_mem"] / 1_000_000
-    plan_df["total_mem_mb"] = plan_df["required_mem_mb"] + baseline_mem_mb
+    plan_df["total_mem_mb"] = plan_df["required_mem_mb"] + reserved_mem_mb
     plan_df = plan_df[
         ["array_name", "op_name", "required_mem_mb", "total_mem_mb", "num_tasks"]
     ]

--- a/cubed/tests/test_mem_utilization.py
+++ b/cubed/tests/test_mem_utilization.py
@@ -12,51 +12,51 @@ from cubed.tests.utils import LITHOPS_LOCAL_CONFIG
 
 
 @pytest.fixture()
-def spec(tmp_path):
-    return cubed.Spec(tmp_path, max_mem=2_000_000_000)
+def spec(tmp_path, reserved_mem):
+    return cubed.Spec(tmp_path, max_mem=2_000_000_000, reserved_mem=reserved_mem)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def reserved_mem():
     executor = LithopsDagExecutor(config=LITHOPS_LOCAL_CONFIG)
-    return cubed.measure_reserved_memory(executor)
+    return cubed.measure_reserved_memory(executor) * 1.05  # add some wiggle room
 
 
 # Array Object
 
 
 @pytest.mark.slow
-def test_index(spec, reserved_mem):
+def test_index(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = a[1:, :]
-    run_operation("index", b, reserved_mem)
+    run_operation("index", b)
 
 
 # Creation Functions
 
 
 @pytest.mark.slow
-def test_eye(spec, reserved_mem):
+def test_eye(spec):
     a = xp.eye(10000, 10000, chunks=(5000, 5000), spec=spec)
-    run_operation("eye", a, reserved_mem)
+    run_operation("eye", a)
 
 
 @pytest.mark.slow
-def test_tril(spec, reserved_mem):
+def test_tril(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.tril(a)
-    run_operation("tril", b, reserved_mem)
+    run_operation("tril", b)
 
 
 # Elementwise Functions
 
 
 @pytest.mark.slow
-def test_add(spec, reserved_mem):
+def test_add(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -64,23 +64,23 @@ def test_add(spec, reserved_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.add(a, b)
-    run_operation("add", c, reserved_mem)
+    run_operation("add", c)
 
 
 @pytest.mark.slow
-def test_negative(spec, reserved_mem):
+def test_negative(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.negative(a)
-    run_operation("negative", b, reserved_mem)
+    run_operation("negative", b)
 
 
 # Linear Algebra Functions
 
 
 @pytest.mark.slow
-def test_matmul(spec, reserved_mem):
+def test_matmul(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -90,20 +90,20 @@ def test_matmul(spec, reserved_mem):
     c = xp.astype(a, xp.float32)
     d = xp.astype(b, xp.float32)
     e = xp.matmul(c, d)
-    run_operation("matmul", e, reserved_mem)
+    run_operation("matmul", e)
 
 
 @pytest.mark.slow
-def test_matrix_transpose(spec, reserved_mem):
+def test_matrix_transpose(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.matrix_transpose(a)
-    run_operation("matrix_transpose", b, reserved_mem)
+    run_operation("matrix_transpose", b)
 
 
 @pytest.mark.slow
-def test_tensordot(spec, reserved_mem):
+def test_tensordot(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -113,14 +113,14 @@ def test_tensordot(spec, reserved_mem):
     c = xp.astype(a, xp.float32)
     d = xp.astype(b, xp.float32)
     e = xp.tensordot(c, d, axes=1)
-    run_operation("tensordot", e, reserved_mem)
+    run_operation("tensordot", e)
 
 
 # Manipulation Functions
 
 
 @pytest.mark.slow
-def test_concat(spec, reserved_mem):
+def test_concat(spec):
     # Note 'a' has one fewer element in axis=0 to force chunking to cross array boundaries
     a = cubed.random.random(
         (9999, 10000), chunks=(5000, 5000), spec=spec
@@ -129,22 +129,22 @@ def test_concat(spec, reserved_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.concat((a, b), axis=0)
-    run_operation("concat", c, reserved_mem)
+    run_operation("concat", c)
 
 
 @pytest.mark.slow
-def test_reshape(spec, reserved_mem):
+def test_reshape(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     # need intermediate reshape due to limitations in Dask's reshape_rechunk
     b = xp.reshape(a, (5000, 2, 10000))
     c = xp.reshape(b, (5000, 20000))
-    run_operation("reshape", c, reserved_mem)
+    run_operation("reshape", c)
 
 
 @pytest.mark.slow
-def test_stack(spec, reserved_mem):
+def test_stack(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
@@ -152,46 +152,46 @@ def test_stack(spec, reserved_mem):
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     c = xp.stack((a, b), axis=0)
-    run_operation("stack", c, reserved_mem)
+    run_operation("stack", c)
 
 
 # Searching Functions
 
 
 @pytest.mark.slow
-def test_argmax(spec, reserved_mem):
+def test_argmax(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.argmax(a, axis=0)
-    run_operation("argmax", b, reserved_mem)
+    run_operation("argmax", b)
 
 
 # Statistical Functions
 
 
 @pytest.mark.slow
-def test_max(spec, reserved_mem):
+def test_max(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.max(a, axis=0)
-    run_operation("max", b, reserved_mem)
+    run_operation("max", b)
 
 
 @pytest.mark.slow
-def test_mean(spec, reserved_mem):
+def test_mean(spec):
     a = cubed.random.random(
         (10000, 10000), chunks=(5000, 5000), spec=spec
     )  # 200MB chunks
     b = xp.mean(a, axis=0)
-    run_operation("mean", b, reserved_mem)
+    run_operation("mean", b)
 
 
 # Internal functions
 
 
-def run_operation(name, result_array, reserved_mem):
+def run_operation(name, result_array):
     # result_array.visualize(f"cubed-{name}-unoptimized", optimize_graph=False)
     # result_array.visualize(f"cubed-{name}")
     executor = LithopsDagExecutor(config=LITHOPS_LOCAL_CONFIG)
@@ -201,7 +201,7 @@ def run_operation(name, result_array, reserved_mem):
 
     plan_df = pd.read_csv(hist.plan_df_path)
     stats_df = pd.read_csv(hist.stats_df_path)
-    df = analyze(plan_df, stats_df, reserved_mem)
+    df = analyze(plan_df, stats_df, result_array.spec.reserved_mem)
     print(df)
 
     # check utilization does not exceed 1

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,7 +64,7 @@ Runtime
     Callback
     Spec
     TaskEndEvent
-    measure_baseline_memory
+    measure_reserved_memory
 
 Executors
 =========


### PR DESCRIPTION
Fixes #59.

Adds a `reserved_mem` parameter to the spec. The idea is that `max_mem + reserved_mem` should never exceed the total worker memory. This is not checked for, but could be via #110.

In the future we might want to change it so you specify `total_mem` and `reserved_mem` (using the `measure_reserved_mem` function), and the system uses `max_mem = total_mem - reserved_mem`.