### PR TITLE
Expose Array not CoreArray (round 2)

### DIFF
--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -20,16 +20,6 @@ class Array(CoreArray):
     def __init__(self, name, zarray, spec, plan):
         super().__init__(name, zarray, spec, plan)
 
-    @classmethod
-    def _maybe_promote(cls, arr: ChunkedArray) -> "Array":
-        """Can be used to coerce a CoreArray to Array. On an Array this should be a no-op."""
-        return Array(
-            name=arr.name,
-            zarray=arr.zarray,
-            spec=arr.spec,
-            plan=arr.plan,
-        )
-
     def __array__(self, dtype=None):
         x = self.compute()
         if dtype and x.dtype != dtype:

--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -12,7 +12,7 @@ from cubed.array_api.dtypes import (
     _numeric_dtypes,
 )
 from cubed.array_api.linear_algebra_functions import matmul
-from cubed.core.array import CoreArray, ChunkedArray
+from cubed.core.array import CoreArray
 from cubed.core.ops import elemwise
 
 
@@ -20,7 +20,7 @@ class Array(CoreArray):
     def __init__(self, name, zarray, spec, plan):
         super().__init__(name, zarray, spec, plan)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None) -> np.ndarray:
         x = self.compute()
         if dtype and x.dtype != dtype:
             x = x.astype(dtype)

--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -38,6 +38,9 @@ class Array(CoreArray):
             x = np.array(x)
         return x
 
+    def __repr__(self):
+        return f"cubed.Array<{self.name}, shape={self.shape}, dtype={self.dtype}, chunks={self.chunks}>"
+
     # Attributes
 
     @property

--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -12,13 +12,23 @@ from cubed.array_api.dtypes import (
     _numeric_dtypes,
 )
 from cubed.array_api.linear_algebra_functions import matmul
-from cubed.core.array import CoreArray
+from cubed.core.array import CoreArray, ChunkedArray
 from cubed.core.ops import elemwise
 
 
 class Array(CoreArray):
     def __init__(self, name, zarray, spec, plan):
         super().__init__(name, zarray, spec, plan)
+
+    @classmethod
+    def _maybe_promote(cls, arr: ChunkedArray) -> "Array":
+        """Can be used to coerce a CoreArray to Array. On an Array this should be a no-op."""
+        return Array(
+            name=arr.name,
+            zarray=arr.zarray,
+            spec=arr.spec,
+            plan=arr.plan,
+        )
 
     def __array__(self, dtype=None):
         x = self.compute()

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -215,8 +215,8 @@ def _linspace(x, *arrays, size, start, step, endpoint, linspace_dtype, block_id=
     )
 
 
-def meshgrid(*arrs, indexing="xy") -> Tuple["Array", ...]:
-    if len({a.dtype for a in arrs}) > 1:
+def meshgrid(*arrays, indexing="xy") -> Tuple["Array", ...]:
+    if len({a.dtype for a in arrays}) > 1:
         raise ValueError("meshgrid inputs must all have the same dtype")
 
     from cubed.array_api.manipulation_functions import broadcast_arrays
@@ -225,22 +225,22 @@ def meshgrid(*arrs, indexing="xy") -> Tuple["Array", ...]:
     if indexing not in ("ij", "xy"):
         raise ValueError("`indexing` must be `'ij'` or `'xy'`")
 
+    arrs = list(arrays)
     if indexing == "xy" and len(arrs) > 1:
-        arrays = list(arrs)  # type: ignore[assignment]
-        arrays[0], arrays[1] = arrs[1], arrs[0]
+        arrs[0], arrs[1] = arrs[1], arrs[0]
 
     grid = []
-    for i in range(len(arrays)):
-        s = len(arrays) * [None]
-        s[i] = slice(None)  # type: ignore[call-overload]
+    for i in range(len(arrs)):
+        s = len(arrs) * [None]
+        s[i] = slice(None) # type: ignore[call-overload]
 
-        r = arrays[i][tuple(s)]
+        r = arrs[i][s]
 
         grid.append(r)
 
     grid = broadcast_arrays(*grid)
 
-    if indexing == "xy" and len(arrays) > 1:
+    if indexing == "xy" and len(arrs) > 1:
         grid[0], grid[1] = grid[1], grid[0]
 
     return tuple(grid)

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -153,8 +153,10 @@ def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None
         write_empty_chunks=False,
     )
 
+    from .array_object import Array
+
     plan = Plan._new(name, "full", target)
-    return CoreArray._new(name, target, spec, plan)
+    return Array(name, target, spec, plan)
 
 
 def full_like(x, /, fill_value, *, dtype=None, device=None, chunks=None, spec=None) -> "Array":

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -16,10 +16,15 @@ from cubed.core import (
 from cubed.core.ops import map_direct
 from cubed.utils import to_chunksize
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .array_object import Array
+
 
 def arange(
     start, /, stop=None, step=1, *, dtype=None, device=None, chunks="auto", spec=None
-):
+) -> Array:
     if stop is None:
         start, stop = 0, start
     num = int(max(np.ceil((stop - start) / step), 0))
@@ -51,7 +56,7 @@ def _arange(a, size, start, stop, step):
     return np.arange(blockstart, min(blockstop, stop), step)
 
 
-def asarray(obj, /, *, dtype=None, device=None, copy=None, chunks="auto", spec=None):
+def asarray(obj, /, *, dtype=None, device=None, copy=None, chunks="auto", spec=None) -> Array:
     a = obj
     from cubed.array_api.array_object import Array
 
@@ -76,22 +81,22 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None, chunks="auto", spec=N
         target[...] = a
 
     plan = Plan._new(name, "asarray", target)
-    return CoreArray._new(name, target, spec, plan)
+    return Array(name, target, spec, plan)
 
 
-def empty(shape, *, dtype=None, device=None, chunks="auto", spec=None):
+def empty(shape, *, dtype=None, device=None, chunks="auto", spec=None) -> Array:
     if dtype is None:
         dtype = np.float64
     return full(shape, None, dtype=dtype, device=device, chunks=chunks, spec=spec)
 
 
-def empty_like(x, /, *, dtype=None, device=None, chunks=None, spec=None):
+def empty_like(x, /, *, dtype=None, device=None, chunks=None, spec=None) -> Array:
     return empty(**_like_args(x, dtype, device, chunks, spec))
 
 
 def eye(
     n_rows, n_cols=None, /, *, k=0, dtype=None, device=None, chunks="auto", spec=None
-):
+) -> Array:
     if n_cols is None:
         n_cols = n_rows
     if dtype is None:
@@ -122,7 +127,7 @@ def _eye(x, *arrays, k=None, chunksize=None, block_id=None):
         return np.zeros_like(x)
 
 
-def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None):
+def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None) -> Array:
     # write to zarr
     # note that write_empty_chunks=False means no chunks are written to disk, so it is very efficient to create large arrays
     shape = normalize_shape(shape)
@@ -151,7 +156,7 @@ def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None
     return CoreArray._new(name, target, spec, plan)
 
 
-def full_like(x, /, fill_value, *, dtype=None, device=None, chunks=None, spec=None):
+def full_like(x, /, fill_value, *, dtype=None, device=None, chunks=None, spec=None) -> Array:
     return full(fill_value=fill_value, **_like_args(x, dtype, device, chunks, spec))
 
 
@@ -166,7 +171,7 @@ def linspace(
     endpoint=True,
     chunks="auto",
     spec=None,
-):
+) -> Array:
     range_ = stop - start
     div = (num - 1) if endpoint else num
     if div == 0:
@@ -207,7 +212,7 @@ def _linspace(x, *arrays, size, start, step, endpoint, linspace_dtype, block_id=
     )
 
 
-def meshgrid(*arrays, indexing="xy"):
+def meshgrid(*arrays, indexing="xy") -> Tuple[Array, ...]:
     if len({a.dtype for a in arrays}) > 1:
         raise ValueError("meshgrid inputs must all have the same dtype")
 
@@ -239,17 +244,17 @@ def meshgrid(*arrays, indexing="xy"):
     return grid
 
 
-def ones(shape, *, dtype=None, device=None, chunks="auto", spec=None):
+def ones(shape, *, dtype=None, device=None, chunks="auto", spec=None) -> Array:
     if dtype is None:
         dtype = np.float64
     return full(shape, 1, dtype=dtype, device=device, chunks=chunks, spec=spec)
 
 
-def ones_like(x, /, *, dtype=None, device=None, chunks=None, spec=None):
+def ones_like(x, /, *, dtype=None, device=None, chunks=None, spec=None) -> Array:
     return ones(**_like_args(x, dtype, device, chunks, spec))
 
 
-def tril(x, /, *, k=0):
+def tril(x, /, *, k=0) -> Array:
     from cubed.array_api.searching_functions import where
 
     if x.ndim < 2:
@@ -259,7 +264,7 @@ def tril(x, /, *, k=0):
     return where(mask, x, zeros_like(x))
 
 
-def triu(x, /, *, k=0):
+def triu(x, /, *, k=0) -> Array:
     from cubed.array_api.searching_functions import where
 
     if x.ndim < 2:
@@ -285,13 +290,13 @@ def _tri_mask(N, M, k, chunks, spec):
     return m
 
 
-def zeros(shape, *, dtype=None, device=None, chunks="auto", spec=None):
+def zeros(shape, *, dtype=None, device=None, chunks="auto", spec=None) -> Array:
     if dtype is None:
         dtype = np.float64
     return full(shape, 0, dtype=dtype, device=device, chunks=chunks, spec=spec)
 
 
-def zeros_like(x, /, *, dtype=None, device=None, chunks=None, spec=None):
+def zeros_like(x, /, *, dtype=None, device=None, chunks=None, spec=None) -> Array:
     return zeros(**_like_args(x, dtype, device, chunks, spec))
 
 

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -28,7 +28,7 @@ def broadcast_arrays(*arrays):
     shape = np.broadcast_shapes(*(e.shape for e in args))
     chunks = broadcast_chunks(*(e.chunks for e in args))
 
-    result = [broadcast_to(e, shape=shape, chunks=chunks) for e in args]
+    result = tuple(broadcast_to(e, shape=shape, chunks=chunks) for e in args)
 
     return result
 

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -27,7 +27,7 @@ def gensym(name="array"):
 
 
 # type representing either a CoreArray or a public-facing Array
-ChunkedArray = TypeVar("ChunkedArray", bound="CoreArray")
+T_ChunkedArray = TypeVar("T_ChunkedArray", bound="CoreArray")
 
 
 class CoreArray:
@@ -123,7 +123,7 @@ class CoreArray:
         if result:
             return result[0]
 
-    def rechunk(self: ChunkedArray, chunks) -> ChunkedArray:
+    def rechunk(self: T_ChunkedArray, chunks) -> T_ChunkedArray:
         """Change the chunking of this array without changing its shape or data.
 
         Parameters
@@ -164,7 +164,7 @@ class CoreArray:
             self, filename=filename, format=format, optimize_graph=optimize_graph
         )
 
-    def __getitem__(self: ChunkedArray, key, /) -> ChunkedArray:
+    def __getitem__(self: T_ChunkedArray, key, /) -> T_ChunkedArray:
         from cubed.core.ops import index
 
         return index(self, key)

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from operator import mul
-from typing import Optional
+from typing import Optional, TypeVar, TYPE_CHECKING
 
 import numpy as np
 from dask.array.core import normalize_chunks
@@ -15,12 +15,19 @@ from .plan import arrays_to_plan
 
 sym_counter = 0
 
+if TYPE_CHECKING:
+    from ..array_api.array_object import Array
+
 
 def gensym(name="array"):
     """Generate a name with an incrementing counter"""
     global sym_counter
     sym_counter += 1
     return f"{name}-{sym_counter:03}"
+
+
+# type representing either a CoreArray or a public-facing Array
+ChunkedArray = TypeVar("ChunkedArray", bound="CoreArray")
 
 
 class CoreArray:
@@ -42,13 +49,6 @@ class CoreArray:
         # and a conservative amount of reserved memory (200MB)
         self.spec = spec or Spec(None, max_mem=100_000_000, reserved_mem=200_000_000)
         self.plan = plan
-
-    @classmethod
-    def _new(cls, name, zarray, spec, plan):
-        # Always create an Array object subclass that has array API methods and attributes
-        from cubed.array_api.array_object import Array
-
-        return Array(name, zarray, spec, plan)
 
     @property
     def chunkmem(self):
@@ -123,7 +123,7 @@ class CoreArray:
         if result:
             return result[0]
 
-    def rechunk(self, chunks):
+    def rechunk(self: ChunkedArray, chunks) -> ChunkedArray:
         """Change the chunking of this array without changing its shape or data.
 
         Parameters
@@ -164,7 +164,7 @@ class CoreArray:
             self, filename=filename, format=format, optimize_graph=optimize_graph
         )
 
-    def __getitem__(self, key, /):
+    def __getitem__(self: ChunkedArray, key, /) -> ChunkedArray:
         from cubed.core.ops import index
 
         return index(self, key)

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -184,7 +184,7 @@ class CoreArray:
         self.zarray.__setitem__(key, value)
 
     def __repr__(self):
-        return f"CoreArray<{self.name}, shape={self.shape}, dtype={self.dtype}, chunks={self.chunks}>"
+        return f"cubed.core.CoreArray<{self.name}, shape={self.shape}, dtype={self.dtype}, chunks={self.chunks}>"
 
 
 @dataclass

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -394,8 +394,8 @@ def map_blocks(
         # Create an array of index offsets with the same chunk structure as the args,
         # which we convert to block ids (chunk coordinates) later.
         a = args[0]
-        offsets = np.arange(a.npartitions, dtype=np.int32).reshape(a.numblocks)
-        offsets = asarray(offsets, spec=a.spec)
+        _offsets = np.arange(a.npartitions, dtype=np.int32).reshape(a.numblocks)
+        offsets = asarray(_offsets, spec=a.spec)
         # rechunk in a separate operation to avoid potentially writing lots of zarr chunks from the client
         offsets_chunks = (1,) * len(a.numblocks)
         offsets = rechunk(offsets, offsets_chunks)

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -93,6 +93,13 @@ def test_asarray_from_array(spec):
     assert_array_equal(b.compute(), np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
 
 
+def test_from_array(spec):
+    nparr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    ca = cubed.from_array(nparr, chunks=(2, 2), spec=spec)
+    assert isinstance(ca, cubed.Array)
+    assert_array_equal(ca.compute(), nparr)
+
+
 @pytest.mark.parametrize("k", [-1, 0, 1])
 def test_eye(spec, k):
     a = xp.eye(5, k=k, chunks=(2, 2), spec=spec)

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -93,13 +93,6 @@ def test_asarray_from_array(spec):
     assert_array_equal(b.compute(), np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
 
 
-def test_from_array(spec):
-    nparr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    ca = cubed.from_array(nparr, chunks=(2, 2), spec=spec)
-    assert isinstance(ca, cubed.Array)
-    assert_array_equal(ca.compute(), nparr)
-
-
 @pytest.mark.parametrize("k", [-1, 0, 1])
 def test_eye(spec, k):
     a = xp.eye(5, k=k, chunks=(2, 2), spec=spec)

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -62,6 +62,7 @@ class WrappedArray:
 )
 def test_from_array(x, chunks, asarray):
     a = cubed.from_array(WrappedArray(x), chunks=chunks, asarray=asarray)
+    assert isinstance(a, cubed.Array)
     assert_array_equal(a, x)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-six.*]
 ignore_missing_imports = True
+[mypy-tenacity.*]
+ignore_missing_imports = True
 [mypy-tlz.*]
 ignore_missing_imports = True
 [mypy-toolz.*]


### PR DESCRIPTION
Follow on from #124.

I'm trying to type the return values so that mypy can verify for me that the correct type is being returned.

I've successfully typed the array creation functions module, but when I got to the ops module I became confused as to how the class design was supposed to work.

You have 

```python
# core/array.py
class CoreArray
    def rechunk(self: ?, chunks) -> ?:
        from cubed.core.ops import rechunk

        return rechunk(self, chunks)


# array_api/array_object.py
def rechunk(x: ?, chunks, ...) -> ?:
    return ...
```

How do you want this to work? Your private subclass is defining public API here. Typing wise this requires that we make `rechunk` pass types through unchanged, so `CoreArray.rechunk` returns `CoreArray` and `Array.rechunk` returns `Array`. This seems not helpful for ensuring that `.rechunk` as seen by the user always returns an `Array`.

I've used `rechunk` as an example here but I think you have a similar typing problem for many of the functions in `ops.py`, and one of the `map_*` functions returning a `CoreArray` is ultimately what's causing `from_array` to return a `CoreArray` (i.e. the specific bug I reported in #123).

Is there some obvious way of rewriting this that would ensure we get the correct type back in the public API?