### PR TITLE
Fix `meshgrid` so it passes array API tests

### DIFF
--- a/cubed/__init__.py
+++ b/cubed/__init__.py
@@ -21,14 +21,7 @@ from .core.array import (
     measure_reserved_memory,
     visualize,
 )
-from .core.ops import (
-    from_array,
-    from_zarr,
-    map_blocks,
-    store,
-    to_zarr,
-)
-
+from .core.ops import from_array, from_zarr, map_blocks, store, to_zarr
 
 __all__ = [
     "__version__",

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -1,23 +1,13 @@
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable, List
 
 import numpy as np
 import zarr
 from dask.array.core import normalize_chunks
 from zarr.util import normalize_shape
 
-from cubed.core import (
-    CoreArray,
-    Plan,
-    gensym,
-    map_blocks,
-    new_temp_store,
-    new_temp_zarr,
-)
+from cubed.core import Plan, gensym, map_blocks, new_temp_store, new_temp_zarr
 from cubed.core.ops import map_direct
 from cubed.utils import to_chunksize
-
-from typing import TYPE_CHECKING, Tuple, List, Union
-
 
 if TYPE_CHECKING:
     from .array_object import Array
@@ -57,7 +47,9 @@ def _arange(a, size, start, stop, step):
     return np.arange(blockstart, min(blockstop, stop), step)
 
 
-def asarray(obj, /, *, dtype=None, device=None, copy=None, chunks="auto", spec=None) -> "Array":
+def asarray(
+    obj, /, *, dtype=None, device=None, copy=None, chunks="auto", spec=None
+) -> "Array":
     a = obj
     from cubed.array_api.array_object import Array
 
@@ -128,7 +120,9 @@ def _eye(x, *arrays, k=None, chunksize=None, block_id=None):
         return np.zeros_like(x)
 
 
-def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None) -> "Array":
+def full(
+    shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None
+) -> "Array":
     # write to zarr
     # note that write_empty_chunks=False means no chunks are written to disk, so it is very efficient to create large arrays
     shape = normalize_shape(shape)
@@ -159,7 +153,9 @@ def full(shape, fill_value, *, dtype=None, device=None, chunks="auto", spec=None
     return Array(name, target, spec, plan)
 
 
-def full_like(x, /, fill_value, *, dtype=None, device=None, chunks=None, spec=None) -> "Array":
+def full_like(
+    x, /, fill_value, *, dtype=None, device=None, chunks=None, spec=None
+) -> "Array":
     return full(fill_value=fill_value, **_like_args(x, dtype, device, chunks, spec))
 
 
@@ -215,7 +211,7 @@ def _linspace(x, *arrays, size, start, step, endpoint, linspace_dtype, block_id=
     )
 
 
-def meshgrid(*arrays, indexing="xy") -> Tuple["Array", ...]:
+def meshgrid(*arrays, indexing="xy") -> List["Array"]:
     if len({a.dtype for a in arrays}) > 1:
         raise ValueError("meshgrid inputs must all have the same dtype")
 
@@ -232,18 +228,18 @@ def meshgrid(*arrays, indexing="xy") -> Tuple["Array", ...]:
     grid = []
     for i in range(len(arrs)):
         s = len(arrs) * [None]
-        s[i] = slice(None) # type: ignore[call-overload]
+        s[i] = slice(None)  # type: ignore[call-overload]
 
-        r = arrs[i][s]
+        r = arrs[i][tuple(s)]
 
         grid.append(r)
 
-    grid = broadcast_arrays(*grid)
+    grid = list(broadcast_arrays(*grid))
 
     if indexing == "xy" and len(arrs) > 1:
         grid[0], grid[1] = grid[1], grid[0]
 
-    return tuple(grid)
+    return grid
 
 
 def ones(shape, *, dtype=None, device=None, chunks="auto", spec=None) -> "Array":

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from operator import mul
-from typing import Optional, TypeVar, TYPE_CHECKING
+from typing import Optional, TypeVar
 
 import numpy as np
 from dask.array.core import normalize_chunks
@@ -14,9 +14,6 @@ from cubed.utils import chunk_memory
 from .plan import arrays_to_plan
 
 sym_counter = 0
-
-if TYPE_CHECKING:
-    from ..array_api.array_object import Array
 
 
 def gensym(name="array"):

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -2,6 +2,7 @@ import numbers
 from functools import partial
 from numbers import Integral, Number
 from operator import add
+from typing import TYPE_CHECKING, Any, Sequence, Union
 
 import numpy as np
 import zarr
@@ -18,9 +19,6 @@ from cubed.core.plan import Plan, new_temp_store
 from cubed.primitive.blockwise import blockwise as primitive_blockwise
 from cubed.primitive.rechunk import rechunk as primitive_rechunk
 from cubed.utils import chunk_memory, get_item, to_chunksize
-
-
-from typing import Any, Sequence, Union, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from cubed.array_api.array_object import Array
@@ -221,7 +219,6 @@ def blockwise(
         if not isinstance(v, tuple):
             v = (v,)
         chunkss[k] = v
-
 
     chunks = [chunkss[i] for i in out_ind]
     if adjust_chunks:


### PR DESCRIPTION
The array API tests failed: https://github.com/tomwhite/cubed/actions/runs/3102948470. This fixes that failure, and also formatting issues (by running `pre-commit run --all-files`).

Note that the array API spec for `meshgrid` says that the return type is `List` (https://data-apis.org/array-api/latest/API_specification/generated/signatures.creation_functions.meshgrid.html), so I fixed that too.

@TomNicholas, I will merge this unless you have any comments or suggestions.

