### PR TITLE
Change the default executor to `PythonDagExecutor` 

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -4,7 +4,6 @@ from typing import Optional, TypeVar
 
 import numpy as np
 from dask.array.core import normalize_chunks
-from rechunker.executors.python import PythonPipelineExecutor
 from toolz import map, reduce
 
 from cubed.runtime.pipeline import already_computed
@@ -293,7 +292,9 @@ def compute(
     if executor is None:
         executor = arrays[0].spec.executor
         if executor is None:
-            executor = PythonPipelineExecutor()
+            from cubed.runtime.executors.python import PythonDagExecutor
+
+            executor = PythonDagExecutor()
 
     _return_in_memory_array = kwargs.pop("_return_in_memory_array", True)
     plan.execute(

--- a/cubed/runtime/executors/python.py
+++ b/cubed/runtime/executors/python.py
@@ -11,7 +11,7 @@ def exec_stage_func(func, *args, **kwargs):
 
 
 class PythonDagExecutor(DagExecutor):
-    """An execution engine that uses Python loops."""
+    """The default execution engine that runs tasks sequentially uses Python loops."""
 
     def execute_dag(self, dag, callbacks=None, array_names=None, **kwargs):
         for name, node in visit_nodes(dag):


### PR DESCRIPTION
(from `PythonPipelineExecutor`), since it supports callbacks