### PR TITLE
Replace use of Dask's `make_blockwise_graph` to `make_blockwise_function`

### DIFF
--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -1,5 +1,4 @@
-import pickle
-
+import dill
 import fsspec
 import numpy as np
 import pytest
@@ -352,7 +351,8 @@ def test_array_pickle(spec, executor):
     c = xp.matmul(a, b)
 
     # we haven't computed c yet, so pickle and unpickle, and check it still works
-    c = pickle.loads(pickle.dumps(c))
+    # note we have to use dill which can serialize local functions, unlike pickle
+    c = dill.loads(dill.dumps(c))
 
     x = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])
     y = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]])

--- a/docs/computation.md
+++ b/docs/computation.md
@@ -33,7 +33,7 @@ The main disadvantage of this model is that every intermediate array is written 
   <dt>Task failure handling</dt>
   <dd>If a task fails - with an IO exception when reading or writing to Zarr, for example - it will be retried (up to a total of three attempts).</dd>
   <dt>Resume a computation from a checkpoint</dt>
-  <dd>Since intermediate arrays are persisted to Zarr, it is possible to resume a computation without starting from scratch. To do this, the Cubed <code>Array</code> object should be stored persistently (using <code>pickle</code>), so it can be reloaded in a new process and then <code>compute()</code> called on it to finish the computation.</dd>
+  <dd>Since intermediate arrays are persisted to Zarr, it is possible to resume a computation without starting from scratch. To do this, the Cubed <code>Array</code> object should be stored persistently (using <code>dill</code>), so it can be reloaded in a new process and then <code>compute()</code> called on it to finish the computation.</dd>
   <dt>Straggler mitigation</dt>
   <dd>A few slow running tasks (called stragglers) can disproportionately slow down the whole computation. To mitigate this, speculative duplicate tasks are launched in certain circumstances, acting as backups that complete more quickly than the straggler, hence bringing down the overall time taken.</dd>
 </dl>

--- a/requirements-modal.txt
+++ b/requirements-modal.txt
@@ -1,5 +1,6 @@
 aiostream
 dask[array]
+dill
 fsspec
 modal-client
 networkx < 2.8.3 # https://github.com/networkx/networkx/pull/5667

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiostream
 apache-beam
 dask[array]
+dill
 fsspec
 lithops[aws] >= 2.7.0
 networkx < 2.8.3 # https://github.com/networkx/networkx/pull/5667


### PR DESCRIPTION
which has the equivalent functionality, but as a function, which reduces serialization overhead.