### PR TITLE
Docs on installing from conda + optional dependencies

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,11 +2,36 @@
 
 ## Installation
 
-Install Cubed with pip:
+### Conda
+
+You can install cubed with a minimal set of dependencies using conda:
+
+```shell
+conda install -c conda-forge cubed
+```
+
+### Pip
+
+You can also install cubed with pip:
 
 ```shell
 python -m pip install cubed
 ```
+
+Cubed has many optional dependencies, which can be installed in sets for different functionality (especially for running on different executors):
+
+    $ python -m pip install "cubed[diagnostics]"  # Install optional dependencies for cubed diagnostics
+    $ python -m pip install "cubed[beam]"         # Install optional dependencies for the beam executor
+    $ python -m pip install "cubed[lithops]"      # Install optional dependencies for the lithops executor
+    $ python -m pip install "cubed[modal]"        # Install optional dependencies for the modal executor
+    $ python -m pip install "cubed[complete]"     # Install all of the above
+
+To see the full list of which packages are installed with which options see `[project.optional_dependencies]` in `pyproject.toml`:
+
+.. literalinclude:: ../pyproject.toml
+   :language: ini
+   :start-at: [projects.optional_dependencies]
+   :end-before: [project.urls]
 
 ## Example
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -27,11 +27,12 @@ Cubed has many optional dependencies, which can be installed in sets for differe
     $ python -m pip install "cubed[complete]"     # Install all of the above
 
 To see the full list of which packages are installed with which options see `[project.optional_dependencies]` in `pyproject.toml`:
-
+```{eval-rst}
 .. literalinclude:: ../pyproject.toml
    :language: ini
-   :start-at: [projects.optional_dependencies]
+   :start-at: [project.optional-dependencies]
    :end-before: [project.urls]
+```
 
 ## Example
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,7 +24,6 @@ Cubed has many optional dependencies, which can be installed in sets for differe
     $ python -m pip install "cubed[beam]"         # Install optional dependencies for the beam executor
     $ python -m pip install "cubed[lithops]"      # Install optional dependencies for the lithops executor
     $ python -m pip install "cubed[modal]"        # Install optional dependencies for the modal executor
-    $ python -m pip install "cubed[complete]"     # Install all of the above
 
 To see the full list of which packages are installed with which options see `[project.optional_dependencies]` in `pyproject.toml`:
 ```{eval-rst}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ modal = [
     "modal-client",
     "s3fs",
 ]
-complete = ["cubed[beam,lithops,modal]"]
 test = [
     "apache-beam",  # beam but not gcsfs as tests use local beam runner
     "cubed[diagnostics,lithops]",  # modal tests separate due to conflicting package reqs


### PR DESCRIPTION
Following #166, documents installing from conda and installing sets of optional dependencies.

Copied the idea of pointing to the actual dependencies specification file from the xarray getting started guide.