### PR TITLE
Convert str to bytes

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -275,6 +275,10 @@ class Spec:
         """Storage options to be passed to fsspec."""
         return self._storage_options
 
+    def __repr__(self) -> str:
+        return f"cubed.Spec(work_dir={self._work_dir}, allowed_mem={self._allowed_mem}, " \
+               f"reserved_mem={self._reserved_mem}, executor={self._executor}, storage_options={self._storage_options})"
+
 
 class Callback:
     """Object to receive callback events during array computation."""

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -189,29 +189,6 @@ class CoreArray:
 class Spec:
     """Specification of resources available to run a computation."""
 
-    # work_dir: Optional[str]
-    # """The directory path (specified as an fsspec URL) used for storing intermediate data."""
-    #
-    # max_mem: Optional[int] = None
-    # """**Deprecated**. The maximum memory available to a worker for data use for the computation, in bytes."""
-    #
-    # allowed_mem: Optional[int] = None
-    # """The total memory available to a worker for running a task, in bytes.
-    #
-    # This includes any ``reserved_mem`` that has been set."""
-    #
-    # reserved_mem: int
-    # """The memory reserved on a worker for non-data use when running a task, in bytes.
-    #
-    # See ``cubed.measure_reserved_memory``.
-    # """
-    #
-    # executor: Executor = None
-    # """The default executor for running computations."""
-    #
-    # storage_options: dict = None  # type: ignore[assignment]
-    # """Storage options to be passed to fsspec"""
-
     def __init__(
         self,
         work_dir: Union[str, None] = None,
@@ -221,6 +198,29 @@ class Spec:
         executor: Union[Executor, None] = None,
         storage_options: Union[dict, None] = None,
     ):
+        """
+        Specify resources available to run a computation.
+
+        Parameters
+        ----------
+        work_dir : str or None
+            The directory path (specified as an fsspec URL) used for storing intermediate data.
+        max_mem : int, optional
+            **Deprecated**. The maximum memory available to a worker for data use for the computation, in bytes.
+        allowed_mem : int or str, optional
+            The total memory available to a worker for running a task, in bytes.
+
+            If int it should be >=0. If str it should be of form <value><unit> where unit can be kB, MB, GB, TB etc.
+            This includes any ``reserved_mem`` that has been set.
+        reserved_mem : int or str, optional
+            The memory reserved on a worker for non-data use when running a task, in bytes.
+
+            If int it should be >=0. If str it should be of form <value><unit> where unit can be kB, MB, GB, TB etc.
+        executor : Executor, optional
+            The default executor for running computations.
+        storage_options : dict, optional
+            Storage options to be passed to fsspec.
+        """
 
         if max_mem is not None:
             warn(
@@ -229,16 +229,51 @@ class Spec:
                 stacklevel=2,
             )
 
-        self.work_dir = work_dir
+        self._work_dir = work_dir
 
-        self.reserved_mem = convert_to_bytes(reserved_mem)
+        self._reserved_mem = convert_to_bytes(reserved_mem)
         if allowed_mem is None:
-            self.allowed_mem = (max_mem or 0) + self.reserved_mem
+            self._allowed_mem = (max_mem or 0) + self.reserved_mem
         else:
-            self.allowed_mem = convert_to_bytes(allowed_mem)
+            self._allowed_mem = convert_to_bytes(allowed_mem)
 
-        self.executor = executor
-        self.storage_options = storage_options
+        self._executor = executor
+        self._storage_options = storage_options
+
+    @property
+    def work_dir(self) -> str:
+        """The directory path (specified as an fsspec URL) used for storing intermediate data."""
+        return self._work_dir
+
+    @property
+    def allowed_mem(self) -> int:
+        """
+        The total memory available to a worker for running a task, in bytes.
+
+        This includes any ``reserved_mem`` that has been set.
+        """
+        return self._allowed_mem
+
+    @property
+    def reserved_mem(self) -> int:
+        """
+        The memory reserved on a worker for non-data use when running a task, in bytes.
+
+        See Also
+        --------
+        cubed.measure_reserved_memory
+        """
+        return self._reserved_mem
+
+    @property
+    def executor(self) -> Executor:
+        """The default executor for running computations."""
+        return self._executor
+
+    @property
+    def storage_options(self) -> dict:
+        """Storage options to be passed to fsspec."""
+        return self._storage_options
 
 
 class Callback:

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -279,6 +279,15 @@ class Spec:
         return f"cubed.Spec(work_dir={self._work_dir}, allowed_mem={self._allowed_mem}, " \
                f"reserved_mem={self._reserved_mem}, executor={self._executor}, storage_options={self._storage_options})"
 
+    def __eq__(self, other):
+        if isinstance(other, Spec):
+            return self.work_dir == other.work_dir \
+                and self.allowed_mem == other.allowed_mem \
+                and self.reserved_mem == other.reserved_mem and self.executor == other.executor \
+                and self.storage_options == other.storage_options
+        else:
+            return False
+
 
 class Callback:
     """Object to receive callback events during array computation."""

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -260,11 +260,11 @@ class TestSpecMemArgTypes:
             (500, 500),
             (100_000, 100_000),
             ("500B", 500),
-            ("1kB", 1024),
-            ("1MB", 1024 ** 2),
-            ("1GB", 1024 ** 3),
-            ("1TB", 1024 ** 4),
-            ("1PB", 1024 ** 5)
+            ("1kB", 1000),
+            ("1MB", 1000 ** 2),
+            ("1GB", 1000 ** 3),
+            ("1TB", 1000 ** 4),
+            ("1PB", 1000 ** 5)
         ]
     )
     def test_convert_to_bytes(self, input_value, expected_value):
@@ -278,7 +278,7 @@ class TestSpecMemArgTypes:
             "1kb",  # lower-case k is not valid
             "invalid",  # completely invalid input
             -512,  # negative integer
-            1024.0,  # invalid type
+            1000.0,  # invalid type
         ]
     )
     def test_convert_to_bytes_error(self, input_value):

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -263,7 +263,8 @@ class TestSpecMemArgTypes:
             ("1kB", 1024),
             ("1MB", 1024 ** 2),
             ("1GB", 1024 ** 3),
-            ("1TB", 1024 ** 4)
+            ("1TB", 1024 ** 4),
+            ("1PB", 1024 ** 5)
         ]
     )
     def test_convert_to_bytes(self, input_value, expected_value):
@@ -273,7 +274,7 @@ class TestSpecMemArgTypes:
     @pytest.mark.parametrize(
         "input_value",
         [
-            "1PB",  # PB is not a valid unit in this function
+            "1EB",  # EB is not a valid unit in this function
             "1kb",  # lower-case k is not valid
             "invalid",  # completely invalid input
             -512,  # negative integer

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -192,6 +192,6 @@ def convert_to_bytes(size: Union[int, str]) -> int:
         if unit in units and value.isdigit():
             value = int(value)
             # convert to bytes
-            return value * (1024 ** units[unit])
+            return value * (1000 ** units[unit])
     else:
         raise ValueError(f"Invalid value: {size}. Expected a positive integer or a string ending with an SI prefix.")

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -174,7 +174,7 @@ def convert_to_bytes(size: Union[int, str]) -> int:
     -------
     int: The size in bytes
     """
-    units = {"B": 0, "kB": 1, "MB": 2, "GB": 3, "TB": 4, "EB": 4}
+    units = {"B": 0, "kB": 1, "MB": 2, "GB": 3, "TB": 4}
 
     if isinstance(size, int) and size >= 0:
         return size

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -157,3 +157,41 @@ def extract_stack_summaries(frame, limit=None):
     stack_summaries.reverse()
 
     return stack_summaries
+
+
+def convert_to_bytes(size: Union[int, str]) -> int:
+    """
+    Converts the input data size to bytes.
+
+    The data size can be expressed as an integer or as a string with different SI prefixes such as '500kB', '2MB', or '1GB'.
+
+    Parameters
+    ----------
+    size: in or str:
+        Size of data. If int it should be >=0. If str it should be of form <value><unit> where unit can be kB, MB, GB, TB etc.
+
+    Returns
+    -------
+    int: The size in bytes
+    """
+    units = {"B": 0, "kB": 1, "MB": 2, "GB": 3, "TB": 4, "EB": 4}
+
+    if isinstance(size, int) and size >= 0:
+        return size
+    elif isinstance(size, str):
+        # check if the format is valid
+        if size[-1] == "B" and size[:-1].isdigit():
+            unit = "B"
+            value = size[:-1]
+        elif size[-2:] in units and size[:-2].isdigit():
+            unit = size[-2:]
+            value = size[:-2]
+        else:
+            raise ValueError(f"Invalid value: {size}. Expected a string ending with an SI prefix.")
+
+        if unit in units and value.isdigit():
+            value = int(value)
+            # convert to bytes
+            return value * (1024 ** units[unit])
+    else:
+        raise ValueError(f"Invalid value: {size}. Expected a positive integer or a string ending with an SI prefix.")

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -174,7 +174,7 @@ def convert_to_bytes(size: Union[int, str]) -> int:
     -------
     int: The size in bytes
     """
-    units = {"B": 0, "kB": 1, "MB": 2, "GB": 3, "TB": 4}
+    units = {"B": 0, "kB": 1, "MB": 2, "GB": 3, "TB": 4, "PB": 5}
 
     if isinstance(size, int) and size >= 0:
         return size


### PR DESCRIPTION
This is just a small quality-of-life improvement that allows passing memory arguments to `Spec` as strings with units, e.g. `allowed_mem='100MB'` rather than `allowed_mem=100_000_000`.

I went down a little rabbit hole learning about how there [isn't a particularly neat way](https://florimond.dev/en/posts/2018/10/reconciling-dataclasses-and-properties-in-python/) of doing input validation on a frozen `dataclass`, and ended up just removing the dataclass in favour of a normal class. 

The `Spec` object is now immutable. It could be mutable, like it technically was before, but I wasn't sure what the intended use was. If `Spec` is just intended as a container of kwargs then it should really be immutable (or even a `NamedTuple`, though that has similar problems with input validation).