### PR TITLE
Show array variable name in visualization

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -248,10 +248,13 @@ class Plan:
                 first_cubed_summary = stack_summaries[first_cubed_i]
                 caller_summary = stack_summaries[first_cubed_i - 1]
 
-                display_name = array_display_names.get(n, "-")
+                if n in array_display_names:
+                    var_name = f" ({array_display_names[n]})"
+                else:
+                    var_name = ""
                 d[
                     "label"
-                ] = f"{display_name}\n{first_cubed_summary.name} {op_name_summary}"
+                ] = f"{n}{var_name}\n{first_cubed_summary.name} {op_name_summary}"
 
                 calls = " -> ".join(
                     [s.name for s in stack_summaries if not s.is_on_python_lib_path()]

--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -195,6 +195,25 @@ class Plan:
             "fontsize": "10",
         }
         dag.graph["node"] = {"fontname": "helvetica", "shape": "box", "fontsize": "10"}
+
+        # do an initial pass to extract array variable names from stack summaries
+        array_display_names = {}
+        for (n, d) in dag.nodes(data=True):
+            if "stack_summaries" in d:
+                stack_summaries = d["stack_summaries"]
+                first_cubed_i = min(
+                    i for i, s in enumerate(stack_summaries) if s.is_cubed()
+                )
+                caller_summary = stack_summaries[first_cubed_i - 1]
+                array_display_names.update(caller_summary.array_names_to_variable_names)
+        # add current stack info
+        frame = inspect.currentframe().f_back  # go back one in the stack
+        stack_summaries = extract_stack_summaries(frame, limit=10)
+        first_cubed_i = min(i for i, s in enumerate(stack_summaries) if s.is_cubed())
+        caller_summary = stack_summaries[first_cubed_i - 1]
+        array_display_names.update(caller_summary.array_names_to_variable_names)
+
+        # now set node attributes with visualization info
         for (n, d) in dag.nodes(data=True):
             if d["op_name"] == "blockwise":
                 d["style"] = "filled"
@@ -209,6 +228,7 @@ class Plan:
             target = d["target"]
             chunkmem = memory_repr(chunk_memory(target.dtype, target.chunks))
             tooltip = (
+                f"name: {n}\n"
                 f"shape: {target.shape}\n"
                 f"chunks: {target.chunks}\n"
                 f"dtype: {target.dtype}\n"
@@ -228,7 +248,10 @@ class Plan:
                 first_cubed_summary = stack_summaries[first_cubed_i]
                 caller_summary = stack_summaries[first_cubed_i - 1]
 
-                d["label"] = f"{n}\n{first_cubed_summary.name} {op_name_summary}"
+                display_name = array_display_names.get(n, "-")
+                d[
+                    "label"
+                ] = f"{display_name}\n{first_cubed_summary.name} {op_name_summary}"
 
                 calls = " -> ".join(
                     [s.name for s in stack_summaries if not s.is_on_python_lib_path()]

--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -114,6 +114,7 @@ class StackSummary:
     lineno: int
     name: str
     module: str
+    array_names_to_variable_names: dict
 
     def is_cubed(self):
         """Return True if this stack frame is a Cubed call."""
@@ -144,14 +145,20 @@ def extract_stack_summaries(frame, limit=None):
             frame_gen = collections.deque(frame_gen, maxlen=-limit)
     # end from StackSummary.extract
 
+    from cubed import Array
+
     stack_summaries = []
     for f, _ in frame_gen:
+        array_names_to_variable_names = {
+            arr.name: var for var, arr in f.f_locals.items() if isinstance(arr, Array)
+        }
         module = f.f_globals.get("__name__", "")
         summary = StackSummary(
             filename=f.f_code.co_filename,
             lineno=f.f_lineno,
             name=f.f_code.co_name,
             module=module,
+            array_names_to_variable_names=array_names_to_variable_names,
         )
         stack_summaries.append(summary)
     stack_summaries.reverse()


### PR DESCRIPTION
This change improves the DAG visualization by using the local variable names for labelling the nodes. This makes it a lot easier to see what is being computed.

I haven't thought about how this works in relation to Xarray, but we should be able to do something similar once the information is available from Xarray (#164).

This is an example from the tests:

```python
a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2))
b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2))
c = xp.add(a, b)
d = c * 2
e = c * 3

e.visualize(filename=tmp_path / "e")
```

Before:
![before](https://github.com/tomwhite/cubed/assets/85085/32e82af3-4678-469a-a91f-1866cee976a7)

After:
![after](https://github.com/tomwhite/cubed/assets/85085/154af1c9-4941-4801-a245-1a28263bb1e6)

Note that you can still see the array names (`array-001` etc.) by hovering over the node to get the tooltip.

It would be nice to include constant expressions too (e.g. '2' and '3' above), but that could be added later.

Any thoughts @TomNicholas?