### PR TITLE
Fix measure reserved

### DIFF
--- a/cubed/__init__.py
+++ b/cubed/__init__.py
@@ -18,6 +18,7 @@ from .core.array import (
     Spec,
     TaskEndEvent,
     compute,
+    measure_reserved_mem,
     measure_reserved_memory,
     visualize,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "from_array",
     "from_zarr",
     "map_blocks",
+    "measure_reserved_mem",
     "measure_reserved_memory",
     "store",
     "to_zarr",

--- a/cubed/core/__init__.py
+++ b/cubed/core/__init__.py
@@ -6,6 +6,7 @@ from .array import (
     TaskEndEvent,
     compute,
     gensym,
+    measure_reserved_mem,
     measure_reserved_memory,
     visualize,
 )

--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -261,7 +261,7 @@ class Spec:
 
         See Also
         --------
-        cubed.measure_reserved_memory
+        cubed.measure_reserved_mem
         """
         return self._reserved_mem
 
@@ -429,6 +429,17 @@ class PeakMeasuredMemoryCallback(Callback):
 
 
 def measure_reserved_memory(
+    executor: Executor, work_dir: Optional[str] = None, **kwargs
+) -> int:
+    warn(
+        "`measure_reserved_memory` is deprecated, please use `measure_reserved_mem` instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return measure_reserved_mem(executor, work_dir=work_dir, **kwargs)
+
+
+def measure_reserved_mem(
     executor: Executor, work_dir: Optional[str] = None, **kwargs
 ) -> int:
     """Measures the reserved memory use for a given executor runtime.

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -484,13 +484,13 @@ def test_already_computed(spec):
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="does not run on windows")
-def test_measure_reserved_memory(executor):
+def test_measure_reserved_mem(executor):
     pytest.importorskip("lithops")
 
     from cubed.runtime.executors.lithops import LithopsDagExecutor
 
     if not isinstance(executor, LithopsDagExecutor):
-        pytest.skip(f"{type(executor)} does not support measure_reserved_memory")
+        pytest.skip(f"{type(executor)} does not support measure_reserved_mem")
 
-    reserved_memory = cubed.measure_reserved_memory(executor=executor)
+    reserved_memory = cubed.measure_reserved_mem(executor=executor)
     assert reserved_memory > 1_000_000  # over 1MB

--- a/cubed/tests/test_mem_utilization.py
+++ b/cubed/tests/test_mem_utilization.py
@@ -20,7 +20,7 @@ def spec(tmp_path, reserved_mem):
 @pytest.fixture(scope="module")
 def reserved_mem():
     executor = LithopsDagExecutor(config=LITHOPS_LOCAL_CONFIG)
-    res = cubed.measure_reserved_memory(executor) * 1.05  # add some wiggle room
+    res = cubed.measure_reserved_mem(executor) * 1.05  # add some wiggle room
     return round_up_to_multiple(res, 10_000_000)  # round up to nearest multiple of 10MB
 
 

--- a/docs/computation.md
+++ b/docs/computation.md
@@ -19,7 +19,7 @@ The maximum amount of memory that tasks are allowed to use must be specified by 
 
 If the `projected_mem` calculated by Cubed is greater than the value of `allowed_mem` set by the user, an exception is raised during the planning phase. This check means that the user can have high confidence that the operation will run within its memory budget.
 
-It is also a good idea to set `reserved_mem`, the amount of memory reserved on a worker for non-data use - it's whatever is needed by the Python process for running a task, and can be estimated using the `measure_reserved_memory` function. Cubed will use `reserved_mem` as a baseline when calculating `projected_mem`, in order to more accurately estimate the upper bound on memory usage.
+It is also a good idea to set `reserved_mem`, the amount of memory reserved on a worker for non-data use - it's whatever is needed by the Python process for running a task, and can be estimated using the `measure_reserved_mem` function. Cubed will use `reserved_mem` as a baseline when calculating `projected_mem`, in order to more accurately estimate the upper bound on memory usage.
 
 The actual (peak) memory usage of each task in a computation can be measured at runtime and analysed to see how well the projected memory matched `peak_measured_mem`. See `HistoryCallback` for details.
 


### PR DESCRIPTION
Fixes #184. Also renames the function to `measure_reserved_mem` to be in line with `reserved_mem` and all of the `*_mem` settings.