### PR TITLE
Lithops retries and backups

### DIFF
--- a/cubed/runtime/executors/lithops_retries.py
+++ b/cubed/runtime/executors/lithops_retries.py
@@ -1,0 +1,161 @@
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from lithops import FunctionExecutor
+from lithops.future import ResponseFuture
+from lithops.wait import ALL_COMPLETED, ALWAYS, ANY_COMPLETED
+from six import reraise
+
+
+class RetryingFuture:
+    """
+    A wrapper around Lithops `ResponseFuture` that takes care of retries.
+    """
+
+    def __init__(
+        self,
+        response_future: ResponseFuture,
+        map_function: Callable,
+        input: Any,
+        map_kwargs: Any = None,
+        retries: Optional[int] = None,
+    ):
+        self.response_future = response_future
+        self.map_function = map_function
+        self.input = input
+        self.map_kwargs = map_kwargs or {}
+        self.retries = retries or 0
+        self.failure_count = 0
+        self.cancelled = False
+
+    def _inc_failure_count(self):
+        self.failure_count += 1
+
+    def _should_retry(self):
+        return not self.cancelled and self.failure_count <= self.retries
+
+    def _retry(self, function_executor: FunctionExecutor):
+        inputs = [self.input]
+        futures_list = function_executor.map(
+            self.map_function, inputs, **self.map_kwargs
+        )
+        self.response_future = futures_list[0]
+
+    def cancel(self):
+        # cancelling will prevent any further retries, but won't affect any running tasks
+        self.cancelled = True
+
+    @property
+    def done(self):
+        return self.response_future.done
+
+    @property
+    def error(self):
+        return self.response_future.error
+
+    @property
+    def _exception(self):
+        return self.response_future._exception
+
+    @property
+    def stats(self):
+        return self.response_future.stats
+
+    def status(
+        self,
+        throw_except: bool = True,
+        internal_storage: Any = None,
+        check_only: bool = False,
+    ):
+        stat = self.response_future.status(
+            throw_except=throw_except,
+            internal_storage=internal_storage,
+            check_only=check_only,
+        )
+        if self.response_future.error:
+            reraise(*self.response_future._exception)
+        return stat
+
+    def result(self, throw_except: bool = True, internal_storage: Any = None):
+        res = self.response_future.result(
+            throw_except=throw_except, internal_storage=internal_storage
+        )
+        if self.response_future.error:
+            reraise(*self.response_future._exception)
+        return res
+
+
+def map_with_retries(
+    function_executor: FunctionExecutor,
+    map_function: Callable,
+    map_iterdata: List[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]],
+    timeout: Optional[int] = None,
+    include_modules: Optional[List[str]] = [],
+    retries: Optional[int] = None,
+) -> List[RetryingFuture]:
+    """
+    A generalisation of Lithops `map`, with retries.
+    """
+
+    inputs = list(map_iterdata)
+    futures_list = function_executor.map(
+        map_function, inputs, timeout=timeout, include_modules=include_modules
+    )
+    return [
+        RetryingFuture(
+            f,
+            map_function=map_function,
+            input=i,
+            map_kwargs=dict(timeout=timeout, include_modules=include_modules),
+            retries=retries,
+        )
+        for i, f in zip(inputs, futures_list)
+    ]
+
+
+def wait_with_retries(
+    function_executor: FunctionExecutor,
+    fs: List[RetryingFuture],
+    throw_except: Optional[bool] = True,
+    return_when: Optional[Any] = ALL_COMPLETED,
+    show_progressbar: Optional[bool] = True,
+) -> Tuple[List[RetryingFuture], List[RetryingFuture]]:
+    """
+    A generalisation of Lithops `wait`, with retries.
+    """
+
+    lookup = {f.response_future: f for f in fs}
+
+    while True:
+        response_futures = [f.response_future for f in fs]
+
+        done, pending = function_executor.wait(
+            response_futures,
+            throw_except=throw_except,
+            return_when=return_when,
+            show_progressbar=show_progressbar,
+        )
+
+        retrying_done = []
+        retrying_pending = [lookup[response_future] for response_future in pending]
+        for response_future in done:
+            retrying_future = lookup[response_future]
+            if response_future.error:
+                retrying_future._inc_failure_count()
+                if retrying_future._should_retry():
+                    retrying_future._retry(function_executor)
+                    # put back into pending since we are retrying this input
+                    retrying_pending.append(retrying_future)
+                    lookup[retrying_future.response_future] = retrying_future
+                else:
+                    retrying_done.append(retrying_future)
+            else:
+                retrying_done.append(retrying_future)
+
+        if return_when == ALWAYS:
+            break
+        elif return_when == ANY_COMPLETED and len(retrying_done) > 0:
+            break
+        elif return_when == ALL_COMPLETED and len(retrying_pending) == 0:
+            break
+
+    return retrying_done, retrying_pending

--- a/cubed/tests/runtime/test_lithops_retries.py
+++ b/cubed/tests/runtime/test_lithops_retries.py
@@ -1,0 +1,69 @@
+import pytest
+from lithops.executors import LocalhostExecutor
+
+from cubed.runtime.executors.lithops_retries import map_with_retries, wait_with_retries
+from cubed.tests.runtime.utils import check_invocation_counts, deterministic_failure
+
+
+def run_test(function, input, retries, timeout=10):
+    with LocalhostExecutor() as executor:
+        futures = map_with_retries(
+            executor,
+            function,
+            input,
+            timeout=timeout,
+            retries=retries,
+        )
+        done, pending = wait_with_retries(executor, futures, throw_except=False)
+        assert len(pending) == 0
+    outputs = set(f.result() for f in done)
+    return outputs
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "timing_map, n_tasks, retries",
+    [
+        # no failures
+        ({}, 3, 2),
+        # first invocation fails
+        ({0: [-1], 1: [-1], 2: [-1]}, 3, 2),
+        # first two invocations fail
+        ({0: [-1, -1], 1: [-1, -1], 2: [-1, -1]}, 3, 2),
+        # first input sleeps once
+        ({0: [20]}, 3, 2),
+    ],
+)
+# fmt: on
+def test_success(tmp_path, timing_map, n_tasks, retries):
+    partial_map_function = lambda x: deterministic_failure(tmp_path, timing_map, x)
+    outputs = run_test(
+        function=partial_map_function,
+        input=range(n_tasks),
+        retries=retries,
+    )
+
+    assert outputs == set(range(n_tasks))
+
+    check_invocation_counts(tmp_path, timing_map, n_tasks, retries)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "timing_map, n_tasks, retries",
+    [
+        # too many failures
+        ({0: [-1], 1: [-1], 2: [-1, -1, -1]}, 3, 2),
+    ],
+)
+# fmt: on
+def test_failure(tmp_path, timing_map, n_tasks, retries):
+    partial_map_function = lambda x: deterministic_failure(tmp_path, timing_map, x)
+    with pytest.raises(RuntimeError):
+        run_test(
+            function=partial_map_function,
+            input=range(n_tasks),
+            retries=retries,
+        )
+
+    check_invocation_counts(tmp_path, timing_map, n_tasks, retries)


### PR DESCRIPTION
This restructures the Lithops code to make retries and backups work more independently of each other (a bit like Modal does, which supports retries natively).

The idea is to build a layer on Lithops that adds retries (96941cc1574ba622564f77857bd19c0d787391d7) and then call that from `map_unordered`, which then only has to handle backups.

I tried this out on Lithops GCF using `lithops-matmul-random.py` with `use_backups=True`. I could see the backup tasks being scheduled, which helped the computation complete faster.

So this is looking promising and can probably be merged soon.