### PR TITLE
Test that plan generation scales to very large workloads

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -216,11 +216,7 @@ class Plan:
         tasks = 0
         for _, node in visit_nodes(dag, resume=resume):
             pipeline = node["pipeline"]
-            for stage in pipeline.stages:
-                if stage.mappable is not None:
-                    tasks += len(list(stage.mappable))
-                else:
-                    tasks += 1
+            tasks += pipeline.num_tasks
         return tasks
 
     def num_arrays(self, optimize_graph: bool = True) -> int:


### PR DESCRIPTION
Changes the `output_blocks` function to an iterable so that the entire list of chunk coordinates isn't materialized during planning. Without this change the test wouldn't complete in any reasonable time; with the change it takes a couple of seconds.

Of course, these huge jobs won't run since currently the entire iterable is materialized before being submitted to the backend. See #239.