### PR TITLE
Dask delayed executor

### DIFF
--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -1,0 +1,37 @@
+import dask
+
+from cubed.core.array import TaskEndEvent
+from cubed.core.plan import visit_nodes
+from cubed.runtime.types import DagExecutor
+
+
+def exec_stage_func(func, *args, **kwargs):
+    # TODO would be good to give the dask tasks useful names
+    return dask.delayed(func(*args, **kwargs))  # should we add pure=True?
+
+
+class DaskDelayedExecutor(DagExecutor):
+    """Executes each stage using dask.Delayed functions."""
+
+    def execute_dag(self, dag, callbacks=None, array_names=None, resume=None, **compute_kwargs):
+        # Note this currently only builds the task graph for each stage once it gets to that stage in computation
+
+        for name, node in visit_nodes(dag, resume=resume):
+            pipeline = node["pipeline"]
+            for stage in pipeline.stages:
+                if stage.mappable is not None:
+                    stage_delayed_funcs = []
+                    for m in stage.mappable:
+                        delayed_func = exec_stage_func(stage.function, m, config=pipeline.config)
+                        stage_delayed_funcs.append(delayed_func)
+                        if callbacks is not None:
+                            event = TaskEndEvent(array_name=name)
+                            [callback.on_task_end(event) for callback in callbacks]
+                else:
+                    delayed_func = exec_stage_func(stage.function, config=pipeline.config)
+                    stage_delayed_funcs = [delayed_func]
+                    if callbacks is not None:
+                        event = TaskEndEvent(array_name=name)
+                        [callback.on_task_end(event) for callback in callbacks]
+
+                dask.persist(stage_delayed_funcs, **compute_kwargs)

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -14,10 +14,10 @@ class DaskDelayedExecutor(DagExecutor):
     """Executes each stage using dask.Delayed functions."""
 
     def execute_dag(
-        self, dag, callbacks=None, array_names=None, resume=None, **compute_kwargs
+        self, dag, callbacks=None, array_names=None, resume=None, client=None, **compute_kwargs
     ):
-        # Note this currently only builds the task graph for each stage once it gets to that stage in computation
 
+        # Note this currently only builds the task graph for each stage once it gets to that stage in computation
         for name, node in visit_nodes(dag, resume=resume):
             pipeline = node["pipeline"]
             for stage in pipeline.stages:
@@ -40,4 +40,4 @@ class DaskDelayedExecutor(DagExecutor):
                         event = TaskEndEvent(array_name=name)
                         [callback.on_task_end(event) for callback in callbacks]
 
-                dask.persist(stage_delayed_funcs, **compute_kwargs)
+                client.persist(stage_delayed_funcs, **compute_kwargs)

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -19,7 +19,6 @@ class DaskDelayedExecutor(DagExecutor):
         callbacks=None,
         array_names=None,
         resume=None,
-        client=None,
         **compute_kwargs,
     ):
         # Note this currently only builds the task graph for each stage once it gets to that stage in computation
@@ -45,4 +44,4 @@ class DaskDelayedExecutor(DagExecutor):
                         event = TaskEndEvent(array_name=name)
                         [callback.on_task_end(event) for callback in callbacks]
 
-                client.persist(*stage_delayed_funcs, **compute_kwargs)
+                dask.compute(*stage_delayed_funcs, **compute_kwargs)

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -45,4 +45,4 @@ class DaskDelayedExecutor(DagExecutor):
                         event = TaskEndEvent(array_name=name)
                         [callback.on_task_end(event) for callback in callbacks]
 
-                client.persist(stage_delayed_funcs, **compute_kwargs)
+                client.persist(*stage_delayed_funcs, **compute_kwargs)

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -1,6 +1,5 @@
 import dask
 
-from cubed.core.array import TaskEndEvent
 from cubed.core.plan import visit_nodes
 from cubed.runtime.types import DagExecutor
 

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -32,16 +32,10 @@ class DaskDelayedExecutor(DagExecutor):
                             stage.function, m, config=pipeline.config
                         )
                         stage_delayed_funcs.append(delayed_func)
-                        if callbacks is not None:
-                            event = TaskEndEvent(array_name=name)
-                            [callback.on_task_end(event) for callback in callbacks]
                 else:
                     delayed_func = exec_stage_func(
                         stage.function, config=pipeline.config
                     )
                     stage_delayed_funcs = [delayed_func]
-                    if callbacks is not None:
-                        event = TaskEndEvent(array_name=name)
-                        [callback.on_task_end(event) for callback in callbacks]
 
                 dask.compute(*stage_delayed_funcs, **compute_kwargs)

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -14,9 +14,14 @@ class DaskDelayedExecutor(DagExecutor):
     """Executes each stage using dask.Delayed functions."""
 
     def execute_dag(
-        self, dag, callbacks=None, array_names=None, resume=None, client=None, **compute_kwargs
+        self,
+        dag,
+        callbacks=None,
+        array_names=None,
+        resume=None,
+        client=None,
+        **compute_kwargs,
     ):
-
         # Note this currently only builds the task graph for each stage once it gets to that stage in computation
         for name, node in visit_nodes(dag, resume=resume):
             pipeline = node["pipeline"]

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -7,7 +7,7 @@ from cubed.runtime.types import DagExecutor
 
 def exec_stage_func(func, *args, **kwargs):
     # TODO would be good to give the dask tasks useful names
-    return dask.delayed(func(*args, **kwargs))  # should we add pure=True?
+    return dask.delayed(func)(*args, **kwargs)  # should we add pure=True?
 
 
 class DaskDelayedExecutor(DagExecutor):

--- a/cubed/runtime/executors/dask.py
+++ b/cubed/runtime/executors/dask.py
@@ -13,7 +13,9 @@ def exec_stage_func(func, *args, **kwargs):
 class DaskDelayedExecutor(DagExecutor):
     """Executes each stage using dask.Delayed functions."""
 
-    def execute_dag(self, dag, callbacks=None, array_names=None, resume=None, **compute_kwargs):
+    def execute_dag(
+        self, dag, callbacks=None, array_names=None, resume=None, **compute_kwargs
+    ):
         # Note this currently only builds the task graph for each stage once it gets to that stage in computation
 
         for name, node in visit_nodes(dag, resume=resume):
@@ -22,13 +24,17 @@ class DaskDelayedExecutor(DagExecutor):
                 if stage.mappable is not None:
                     stage_delayed_funcs = []
                     for m in stage.mappable:
-                        delayed_func = exec_stage_func(stage.function, m, config=pipeline.config)
+                        delayed_func = exec_stage_func(
+                            stage.function, m, config=pipeline.config
+                        )
                         stage_delayed_funcs.append(delayed_func)
                         if callbacks is not None:
                             event = TaskEndEvent(array_name=name)
                             [callback.on_task_end(event) for callback in callbacks]
                 else:
-                    delayed_func = exec_stage_func(stage.function, config=pipeline.config)
+                    delayed_func = exec_stage_func(
+                        stage.function, config=pipeline.config
+                    )
                     stage_delayed_funcs = [delayed_func]
                     if callbacks is not None:
                         event = TaskEndEvent(array_name=name)


### PR DESCRIPTION
Would close #161. Also an example of #224.

The idea of this executor is that instead of guaranteeing that each instance doesn't exceed `allowed_mem` because it only sees one function to run (i.e. serverless), we are relying on dask.distributed's workers to each fully execute one delayed func before starting another (i.e. to not fall foul of [root task overproduction](https://www.coiled.io/blog/reducing-dask-memory-usage)). The embarassingly parallel nature of the list of `dask.Delayed` objects is what should hopefully keep the scheduler behaving predictably. Then the peak memory usage of the dask cluster *should* be just `n_workers` * `projected_mem`.

I haven't properly tried this yet, I just wanted to push this as a WIP, because it seems to work for a simple test case

![Screenshot from 2023-06-28 12-47-32](https://github.com/tomwhite/cubed/assets/35968931/f78ada57-999b-4947-b767-7b0bbd486b6b)


I literally just copied how the sequential python executor works but wrapped `exec_stage_func` in `dask.delayed`. Currently this means that a new list of `dask.Delayed` objects is created then computed for each step in the cubed pipeline. I think the more advanced implementation would look more like [rechunker's dask executor](https://github.com/pangeo-data/rechunker/blob/master/rechunker/executors/dask.py), which builds each layer then creates a HLG before anything is computed.