### PR TITLE
Surface rechunk intermediates in DAG

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -41,7 +41,6 @@ class Plan:
         name,
         op_name,
         target,
-        intermediate_target=None,
         pipeline=None,
         projected_mem=None,
         reserved_mem=None,
@@ -77,16 +76,6 @@ class Plan:
                 projected_mem=projected_mem,
                 reserved_mem=reserved_mem,
                 num_tasks=num_tasks,
-            )
-        if intermediate_target is not None:
-            intermediate_name = f"{name}-intermediate"
-            dag.add_node(
-                intermediate_name,
-                name=intermediate_name,
-                op_name=op_name,
-                target=intermediate_target,
-                stack_summaries=stack_summaries,
-                hidden=True,
             )
         for x in source_arrays:
             if hasattr(x, "name"):
@@ -288,6 +277,8 @@ class Plan:
                 pipeline = d["pipeline"]
                 tooltip += f"\nprojected memory: {memory_repr(pipeline.projected_mem)}"
                 tooltip += f"\ntasks: {pipeline.num_tasks}"
+                if pipeline.write_chunks is not None:
+                    tooltip += f"\nwrite chunks: {pipeline.write_chunks}"
             if "stack_summaries" in d and d["stack_summaries"] is not None:
                 # add call stack information
                 stack_summaries = d["stack_summaries"]
@@ -416,4 +407,4 @@ def create_zarr_arrays(lazy_zarr_arrays, reserved_mem):
     )
     num_tasks = len(lazy_zarr_arrays)
 
-    return CubedPipeline(stages, None, None, None, projected_mem, num_tasks)
+    return CubedPipeline(stages, None, None, projected_mem, num_tasks, None)

--- a/cubed/primitive/blockwise.py
+++ b/cubed/primitive/blockwise.py
@@ -228,7 +228,7 @@ def blockwise(
             f"Projected blockwise memory ({projected_mem}) exceeds allowed_mem ({allowed_mem}), including reserved_mem ({reserved_mem})"
         )
 
-    return CubedPipeline(stages, spec, target_array, None, projected_mem, num_tasks)
+    return CubedPipeline(stages, spec, target_array, projected_mem, num_tasks, None)
 
 
 # Code for fusing pipelines
@@ -281,7 +281,7 @@ def fuse(pipeline1: CubedPipeline, pipeline2: CubedPipeline) -> CubedPipeline:
     projected_mem = max(pipeline1.projected_mem, pipeline2.projected_mem)
     num_tasks = pipeline2.num_tasks
 
-    return CubedPipeline(stages, spec, target_array, None, projected_mem, num_tasks)
+    return CubedPipeline(stages, spec, target_array, projected_mem, num_tasks, None)
 
 
 # blockwise functions

--- a/cubed/primitive/types.py
+++ b/cubed/primitive/types.py
@@ -15,9 +15,9 @@ class CubedPipeline:
     stages: Sequence[Stage]
     config: Config
     target_array: Any
-    intermediate_array: Optional[Any]
     projected_mem: int
     num_tasks: int
+    write_chunks: Optional[T_RegularChunks]
 
 
 class CubedArrayProxy:
@@ -36,5 +36,4 @@ class CubedCopySpec:
     """Generalisation of rechunker ``CopySpec`` with support for ``LazyZarrArray``."""
 
     read: CubedArrayProxy
-    intermediate: CubedArrayProxy
     write: CubedArrayProxy

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -220,6 +220,16 @@ def test_rechunk_same_chunks(spec):
     assert_array_equal(res, np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
 
 
+# see also test_rechunk.py
+def test_rechunk_intermediate(tmp_path):
+    spec = cubed.Spec(tmp_path, allowed_mem=4 * 8 * 4)
+    a = xp.ones((4, 4), chunks=(1, 4), spec=spec)
+    b = a.rechunk((4, 1))
+    assert_array_equal(b.compute(), np.ones((4, 4)))
+    intermediates = [n for (n, d) in b.plan.dag.nodes(data=True) if "-int" in d["name"]]
+    assert len(intermediates) == 1
+
+
 def test_compute_is_idempotent(spec, executor):
     a = xp.ones((3, 3), chunks=(2, 2), spec=spec)
     b = xp.negative(a)


### PR DESCRIPTION
Fixes #222

Note that with #249 intermediates in rechunks are less common, and with #256 (not yet merged) rechunk operations themselves will be a lot less common. However, this change is still useful since it is an overall simplification (and removes about 40 lines of code).

Here's an example before/after plan:

![cubed](https://github.com/tomwhite/cubed/assets/85085/ed100895-5c0c-42bd-9ef1-be6ae7c27076)

![cubed](https://github.com/tomwhite/cubed/assets/85085/1f8ab428-a74f-4a43-9776-ae0d097878f1)

(Note that the number of tasks has increased since it was undercounting before.)