### PR TITLE
Lithops compute arrays in parallel

### DIFF
--- a/cubed/runtime/executors/lithops.py
+++ b/cubed/runtime/executors/lithops.py
@@ -66,7 +66,6 @@ def map_unordered(
     """
     return_when = ALWAYS if use_backups else ANY_COMPLETED
 
-    inputs = list(map_iterdata)
     start_times = {}
     end_times = {}
     backups: Dict[RetryingFuture, RetryingFuture] = {}
@@ -79,7 +78,7 @@ def map_unordered(
     futures = map_with_retries(
         lithops_function_executor,
         partial_map_function,
-        inputs,
+        map_iterdata,
         timeout=timeout,
         include_modules=include_modules,
         retries=retries,

--- a/cubed/runtime/executors/lithops_retries.py
+++ b/cubed/runtime/executors/lithops_retries.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from lithops import FunctionExecutor
 from lithops.future import ResponseFuture
@@ -87,7 +87,7 @@ class RetryingFuture:
 def map_with_retries(
     function_executor: FunctionExecutor,
     map_function: Callable[..., Any],
-    map_iterdata: List[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]],
+    map_iterdata: Iterable[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]],
     timeout: Optional[int] = None,
     include_modules: Optional[List[str]] = [],
     retries: Optional[int] = None,

--- a/cubed/runtime/executors/lithops_retries.py
+++ b/cubed/runtime/executors/lithops_retries.py
@@ -18,12 +18,14 @@ class RetryingFuture:
         input: Any,
         map_kwargs: Any = None,
         retries: Optional[int] = None,
+        group_name: Optional[str] = None,
     ):
         self.response_future = response_future
         self.map_function = map_function
         self.input = input
         self.map_kwargs = map_kwargs or {}
         self.retries = retries or 0
+        self.group_name = group_name
         self.failure_count = 0
         self.cancelled = False
 
@@ -91,6 +93,7 @@ def map_with_retries(
     timeout: Optional[int] = None,
     include_modules: Optional[List[str]] = [],
     retries: Optional[int] = None,
+    group_name: Optional[str] = None,
 ) -> List[RetryingFuture]:
     """
     A generalisation of Lithops `map`, with retries.
@@ -107,6 +110,7 @@ def map_with_retries(
             input=i,
             map_kwargs=dict(timeout=timeout, include_modules=include_modules),
             retries=retries,
+            group_name=group_name,
         )
         for i, f in zip(inputs, futures_list)
     ]

--- a/cubed/tests/runtime/test_lithops.py
+++ b/cubed/tests/runtime/test_lithops.py
@@ -17,8 +17,9 @@ def run_test(function, input, retries, timeout=10, use_backups=False):
     with LocalhostExecutor() as executor:
         for output in map_unordered(
             executor,
-            function,
-            input,
+            [function],
+            [input],
+            ["group0"],
             timeout=timeout,
             retries=retries,
             use_backups=use_backups,

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -557,7 +557,16 @@ def test_plan_scaling(tmp_path, factor):
 def test_compute_arrays_in_parallel(spec, any_executor, compute_arrays_in_parallel):
     from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
 
-    if not isinstance(any_executor, AsyncPythonDagExecutor):
+    supported_executors = [AsyncPythonDagExecutor]
+
+    try:
+        from cubed.runtime.executors.lithops import LithopsDagExecutor
+
+        supported_executors.append(LithopsDagExecutor)
+    except ImportError:
+        pass
+
+    if not isinstance(any_executor, tuple(supported_executors)):
         pytest.skip(f"{type(any_executor)} does not support compute_arrays_in_parallel")
 
     a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)


### PR DESCRIPTION
This is #80 for Lithops.

I'm still experimenting with this, but you can see the effect here, where the first two arrays (from `lithops-add-random.py`) are computed at the same time, rather than sequentially:

![1689264590_timeline](https://github.com/tomwhite/cubed/assets/85085/9a040382-2e86-4cef-87cb-5dad2992e300)
