### PR TITLE
Generalise async executor code

### DIFF
--- a/cubed/runtime/executors/asyncio.py
+++ b/cubed/runtime/executors/asyncio.py
@@ -1,0 +1,83 @@
+import asyncio
+import copy
+import time
+from asyncio import Future
+from typing import Any, AsyncIterator, Callable, Dict, Iterable, List, Optional, Tuple
+
+from cubed.runtime.backup import should_launch_backup
+
+
+async def async_map_unordered(
+    create_futures_func: Callable[..., List[Tuple[Any, Future]]],
+    input: Iterable[Any],
+    use_backups: bool = False,
+    create_backup_futures_func: Optional[
+        Callable[..., List[Tuple[Any, Future]]]
+    ] = None,
+    return_stats: bool = False,
+    name: Optional[str] = None,
+    **kwargs,
+) -> AsyncIterator[Any]:
+    """
+    Asynchronous parallel map over an iterable input, with support for backups and batching.
+    """
+
+    if create_backup_futures_func is None:
+        create_backup_futures_func = create_futures_func
+
+    task_create_tstamp = time.time()
+    tasks = {task: i for i, task in create_futures_func(input, **kwargs)}
+    pending = set(tasks.keys())
+    t = time.monotonic()
+    start_times = {f: t for f in pending}
+    end_times = {}
+    backups: Dict[asyncio.Future, asyncio.Future] = {}
+
+    while pending:
+        finished, pending = await asyncio.wait(
+            pending, return_when=asyncio.FIRST_COMPLETED, timeout=2
+        )
+        for task in finished:
+            # TODO: use exception groups in Python 3.11 to handle case of multiple task exceptions
+            if task.exception():
+                # if the task has a backup that is not done, or is done with no exception, then don't raise this exception
+                backup = backups.get(task, None)
+                if backup:
+                    if not backup.done() or not backup.exception():
+                        continue
+                raise task.exception()
+            end_times[task] = time.monotonic()
+            if return_stats:
+                result, stats = task.result()
+                if name is not None:
+                    stats["array_name"] = name
+                stats["task_create_tstamp"] = task_create_tstamp
+                yield result, stats
+            else:
+                yield task.result()
+
+            # remove any backup task
+            if use_backups:
+                backup = backups.get(task, None)
+                if backup:
+                    if backup in pending:
+                        pending.remove(backup)
+                    del backups[task]
+                    del backups[backup]
+                    backup.cancel()
+
+        if use_backups:
+            now = time.monotonic()
+            for task in copy.copy(pending):
+                if task not in backups and should_launch_backup(
+                    task, now, start_times, end_times
+                ):
+                    # launch backup task
+                    print("Launching backup task")
+                    i = tasks[task]
+                    i, new_task = create_backup_futures_func([i], **kwargs)[0]
+                    tasks[new_task] = i
+                    start_times[new_task] = time.monotonic()
+                    pending.add(new_task)
+                    backups[task] = new_task
+                    backups[new_task] = task

--- a/cubed/tests/runtime/test_modal_async.py
+++ b/cubed/tests/runtime/test_modal_async.py
@@ -36,6 +36,11 @@ def deterministic_failure_modal(i, path=None, timing_map=None):
     return deterministic_failure(path, timing_map, i)
 
 
+@stub.function(image=image, secret=modal.Secret.from_name("my-aws-secret"), timeout=10)
+def deterministic_failure_modal_no_retries(i, path=None, timing_map=None):
+    return deterministic_failure(path, timing_map, i)
+
+
 @stub.function(
     image=image, secret=modal.Secret.from_name("my-aws-secret"), retries=2, timeout=300
 )
@@ -47,7 +52,10 @@ async def run_test(app_function, input, use_backups=False, **kwargs):
     outputs = set()
     async with stub.run():
         async for output in map_unordered(
-            app_function, input, use_backups=use_backups, **kwargs
+            app_function,
+            input,
+            use_backups=use_backups,
+            **kwargs,
         ):
             outputs.add(output)
     return outputs

--- a/cubed/tests/runtime/test_python_async.py
+++ b/cubed/tests/runtime/test_python_async.py
@@ -8,13 +8,20 @@ from cubed.runtime.executors.python_async import map_unordered
 from cubed.tests.runtime.utils import check_invocation_counts, deterministic_failure
 
 
-async def run_test(function, input, retries=2):
+async def run_test(function, input, retries=2, use_backups=False):
     outputs = set()
-    with ThreadPoolExecutor() as concurrent_executor:
+    concurrent_executor = ThreadPoolExecutor()
+    try:
         async for output in map_unordered(
-            concurrent_executor, function, input, retries=retries
+            concurrent_executor,
+            function,
+            input,
+            retries=retries,
+            use_backups=use_backups,
         ):
             outputs.add(output)
+    finally:
+        concurrent_executor.shutdown(wait=False)
     return outputs
 
 
@@ -62,5 +69,29 @@ def test_failure(tmp_path, timing_map, n_tasks, retries):
                 retries=retries,
             )
         )
+
+    check_invocation_counts(tmp_path, timing_map, n_tasks, retries)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "timing_map, n_tasks, retries",
+    [
+        ({0: [60]}, 10, 2),
+    ],
+)
+# fmt: on
+@pytest.mark.skip(reason="This passes, but Python will not exit until the slow task is done.")
+def test_stragglers(tmp_path, timing_map, n_tasks, retries):
+    outputs = asyncio.run(
+        run_test(
+            function=partial(deterministic_failure, tmp_path, timing_map),
+            input=range(n_tasks),
+            retries=retries,
+            use_backups=True,
+        )
+    )
+
+    assert outputs == set(range(n_tasks))
 
     check_invocation_counts(tmp_path, timing_map, n_tasks, retries)

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -1,7 +1,6 @@
 import platform
 
 import dill
-import fsspec
 import numpy as np
 import pytest
 import zarr
@@ -11,11 +10,6 @@ import cubed
 import cubed.array_api as xp
 import cubed.random
 from cubed.core.ops import merge_chunks
-from cubed.extensions.history import HistoryCallback
-from cubed.extensions.timeline import TimelineVisualizationCallback
-from cubed.extensions.tqdm import TqdmProgressBar
-from cubed.primitive.blockwise import apply_blockwise
-from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
 from cubed.tests.utils import (
     ALL_EXECUTORS,
     MAIN_EXECUTORS,
@@ -456,112 +450,6 @@ def test_array_pickle(spec, executor):
     assert_array_equal(c.compute(executor=executor), expected)
 
 
-mock_call_counter = 0
-
-
-def mock_apply_blockwise(*args, **kwargs):
-    # Raise an error on every 3rd call
-    global mock_call_counter
-    mock_call_counter += 1
-    if mock_call_counter % 3 == 0:
-        raise IOError("Test fault injection")
-    return apply_blockwise(*args, **kwargs)
-
-
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="measuring memory does not run on windows"
-)
-def test_retries(mocker, spec):
-    # Use AsyncPythonDagExecutor since PythonDagExecutor doesn't support retries
-    executor = AsyncPythonDagExecutor()
-    # Inject faults into the primitive layer
-    mocker.patch(
-        "cubed.primitive.blockwise.apply_blockwise", side_effect=mock_apply_blockwise
-    )
-
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
-    c = xp.add(a, b)
-    assert_array_equal(
-        c.compute(executor=executor), np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]])
-    )
-
-
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="measuring memory does not run on windows"
-)
-def test_callbacks(spec, executor):
-    try:
-        from cubed.runtime.executors.dask import DaskDelayedExecutor
-
-        if isinstance(executor, DaskDelayedExecutor):
-            pytest.skip(f"{type(executor)} does not support callbacks")
-    except ImportError:
-        pass
-
-    task_counter = TaskCounter()
-    # test following indirectly by checking they don't cause a failure
-    progress = TqdmProgressBar()
-    hist = HistoryCallback()
-    timeline_viz = TimelineVisualizationCallback()
-
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
-    c = xp.add(a, b)
-    assert_array_equal(
-        c.compute(
-            executor=executor, callbacks=[task_counter, progress, hist, timeline_viz]
-        ),
-        np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]]),
-    )
-
-    num_created_arrays = 3
-    assert task_counter.value == num_created_arrays + 4
-
-
-@pytest.mark.cloud
-def test_callbacks_modal(spec, modal_executor):
-    task_counter = TaskCounter(check_timestamps=False)
-    tmp_path = "s3://cubed-unittest/callbacks"
-    spec = cubed.Spec(tmp_path, allowed_mem=100000)
-    try:
-        a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-        b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
-        c = xp.add(a, b)
-        assert_array_equal(
-            c.compute(executor=modal_executor, callbacks=[task_counter]),
-            np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]]),
-        )
-
-        num_created_arrays = 3
-        assert task_counter.value == num_created_arrays + 4
-    finally:
-        fs = fsspec.open(tmp_path).fs
-        fs.rm(tmp_path, recursive=True)
-
-
-def test_already_computed(spec):
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
-    c = xp.add(a, b)
-    d = xp.negative(c)
-
-    num_created_arrays = 4  # a, b, c, d
-    assert d.plan.num_tasks(optimize_graph=False) == num_created_arrays + 8
-
-    task_counter = TaskCounter()
-    c.compute(callbacks=[task_counter], optimize_graph=False)
-    num_created_arrays = 3  # a, b, c
-    assert task_counter.value == num_created_arrays + 4
-
-    # since c has already been computed, when computing d only 4 tasks are run, instead of 8
-    task_counter = TaskCounter()
-    d.compute(callbacks=[task_counter], optimize_graph=False, resume=True)
-    # the create arrays tasks are run again, even though they exist
-    num_created_arrays = 4  # a, b, c, d
-    assert task_counter.value == num_created_arrays + 4
-
-
 @pytest.mark.skipif(platform.system() == "Windows", reason="does not run on windows")
 def test_measure_reserved_mem(executor):
     pytest.importorskip("lithops")
@@ -590,68 +478,3 @@ def test_plan_scaling(tmp_path, factor):
 
     assert c.plan.num_tasks() > 0
     c.visualize(filename=tmp_path / "c")
-
-
-@pytest.mark.parametrize("compute_arrays_in_parallel", [True, False])
-def test_compute_arrays_in_parallel(spec, any_executor, compute_arrays_in_parallel):
-    from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
-
-    supported_executors = [AsyncPythonDagExecutor]
-
-    try:
-        from cubed.runtime.executors.lithops import LithopsDagExecutor
-
-        supported_executors.append(LithopsDagExecutor)
-    except ImportError:
-        pass
-
-    if not isinstance(any_executor, tuple(supported_executors)):
-        pytest.skip(f"{type(any_executor)} does not support compute_arrays_in_parallel")
-
-    a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
-    b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
-    c = xp.add(a, b)
-
-    c.compute(
-        executor=any_executor, compute_arrays_in_parallel=compute_arrays_in_parallel
-    )
-
-
-@pytest.mark.cloud
-@pytest.mark.parametrize("compute_arrays_in_parallel", [True, False])
-def test_compute_arrays_in_parallel_modal(modal_executor, compute_arrays_in_parallel):
-    from cubed.runtime.executors.modal_async import AsyncModalDagExecutor
-
-    if not isinstance(modal_executor, AsyncModalDagExecutor):
-        pytest.skip(
-            f"{type(modal_executor)} does not support compute_arrays_in_parallel"
-        )
-
-    tmp_path = "s3://cubed-unittest/parallel_pipelines"
-    spec = cubed.Spec(tmp_path, allowed_mem=100000)
-    try:
-        a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
-        b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
-        c = xp.add(a, b)
-
-        c.compute(
-            executor=modal_executor,
-            compute_arrays_in_parallel=compute_arrays_in_parallel,
-        )
-    finally:
-        fs = fsspec.open(tmp_path).fs
-        fs.rm(tmp_path, recursive=True)
-
-
-@pytest.mark.cloud
-def test_check_runtime_memory_modal(spec, modal_executor):
-    tmp_path = "s3://cubed-unittest/check-runtime-memory"
-    spec = cubed.Spec(tmp_path, allowed_mem="4GB")  # larger than Modal runtime memory
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
-    c = xp.add(a, b)
-    with pytest.raises(
-        ValueError,
-        match=r"Runtime memory \(2097152000\) is less than allowed_mem \(4000000000\)",
-    ):
-        c.compute(executor=modal_executor)

--- a/cubed/tests/test_executor_features.py
+++ b/cubed/tests/test_executor_features.py
@@ -1,0 +1,229 @@
+import platform
+
+import fsspec
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+import cubed
+import cubed.array_api as xp
+import cubed.random
+from cubed.extensions.history import HistoryCallback
+from cubed.extensions.timeline import TimelineVisualizationCallback
+from cubed.extensions.tqdm import TqdmProgressBar
+from cubed.primitive.blockwise import apply_blockwise
+from cubed.runtime.executors.python_async import AsyncPythonDagExecutor
+from cubed.tests.utils import (
+    ALL_EXECUTORS,
+    MAIN_EXECUTORS,
+    MODAL_EXECUTORS,
+    TaskCounter,
+)
+
+
+@pytest.fixture()
+def spec(tmp_path):
+    return cubed.Spec(tmp_path, allowed_mem=100000)
+
+
+@pytest.fixture(scope="module", params=MAIN_EXECUTORS)
+def executor(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=ALL_EXECUTORS)
+def any_executor(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=MODAL_EXECUTORS)
+def modal_executor(request):
+    return request.param
+
+
+mock_call_counter = 0
+
+
+def mock_apply_blockwise(*args, **kwargs):
+    # Raise an error on every 3rd call
+    global mock_call_counter
+    mock_call_counter += 1
+    if mock_call_counter % 3 == 0:
+        raise IOError("Test fault injection")
+    return apply_blockwise(*args, **kwargs)
+
+
+# see tests/runtime for more tests for retries for other executors
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="measuring memory does not run on windows"
+)
+def test_retries(mocker, spec):
+    # Use AsyncPythonDagExecutor since PythonDagExecutor doesn't support retries
+    executor = AsyncPythonDagExecutor()
+    # Inject faults into the primitive layer
+    mocker.patch(
+        "cubed.primitive.blockwise.apply_blockwise", side_effect=mock_apply_blockwise
+    )
+
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+    c = xp.add(a, b)
+    assert_array_equal(
+        c.compute(executor=executor), np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]])
+    )
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="measuring memory does not run on windows"
+)
+def test_callbacks(spec, executor):
+    try:
+        from cubed.runtime.executors.dask import DaskDelayedExecutor
+
+        if isinstance(executor, DaskDelayedExecutor):
+            pytest.skip(f"{type(executor)} does not support callbacks")
+    except ImportError:
+        pass
+
+    task_counter = TaskCounter()
+    # test following indirectly by checking they don't cause a failure
+    progress = TqdmProgressBar()
+    hist = HistoryCallback()
+    timeline_viz = TimelineVisualizationCallback()
+
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+    c = xp.add(a, b)
+    assert_array_equal(
+        c.compute(
+            executor=executor, callbacks=[task_counter, progress, hist, timeline_viz]
+        ),
+        np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]]),
+    )
+
+    num_created_arrays = 3
+    assert task_counter.value == num_created_arrays + 4
+
+
+@pytest.mark.cloud
+def test_callbacks_modal(spec, modal_executor):
+    task_counter = TaskCounter(check_timestamps=False)
+    tmp_path = "s3://cubed-unittest/callbacks"
+    spec = cubed.Spec(tmp_path, allowed_mem=100000)
+    try:
+        a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+        b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+        c = xp.add(a, b)
+        assert_array_equal(
+            c.compute(executor=modal_executor, callbacks=[task_counter]),
+            np.array([[2, 3, 4], [5, 6, 7], [8, 9, 10]]),
+        )
+
+        num_created_arrays = 3
+        assert task_counter.value == num_created_arrays + 4
+    finally:
+        fs = fsspec.open(tmp_path).fs
+        fs.rm(tmp_path, recursive=True)
+
+
+def test_resume(spec, executor):
+    try:
+        from cubed.runtime.executors.beam import BeamDagExecutor
+
+        if isinstance(executor, BeamDagExecutor):
+            pytest.skip(f"{type(executor)} does not support resume")
+    except ImportError:
+        pass
+
+    try:
+        from cubed.runtime.executors.dask import DaskDelayedExecutor
+
+        if isinstance(executor, DaskDelayedExecutor):
+            pytest.skip(f"{type(executor)} does not support resume")
+    except ImportError:
+        pass
+
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+    c = xp.add(a, b)
+    d = xp.negative(c)
+
+    num_created_arrays = 4  # a, b, c, d
+    assert d.plan.num_tasks(optimize_graph=False) == num_created_arrays + 8
+
+    task_counter = TaskCounter()
+    c.compute(executor=executor, callbacks=[task_counter], optimize_graph=False)
+    num_created_arrays = 3  # a, b, c
+    assert task_counter.value == num_created_arrays + 4
+
+    # since c has already been computed, when computing d only 4 tasks are run, instead of 8
+    task_counter = TaskCounter()
+    d.compute(
+        executor=executor, callbacks=[task_counter], optimize_graph=False, resume=True
+    )
+    # the create arrays tasks are run again, even though they exist
+    num_created_arrays = 4  # a, b, c, d
+    assert task_counter.value == num_created_arrays + 4
+
+
+@pytest.mark.parametrize("compute_arrays_in_parallel", [True, False])
+def test_compute_arrays_in_parallel(spec, any_executor, compute_arrays_in_parallel):
+    try:
+        from cubed.runtime.executors.beam import BeamDagExecutor
+
+        if isinstance(any_executor, BeamDagExecutor):
+            pytest.skip(
+                f"{type(any_executor)} does not support compute_arrays_in_parallel"
+            )
+    except ImportError:
+        pass
+
+    a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
+    b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
+    c = xp.add(a, b)
+
+    # note that this merely checks that compute_arrays_in_parallel is accepted
+    c.compute(
+        executor=any_executor, compute_arrays_in_parallel=compute_arrays_in_parallel
+    )
+
+
+@pytest.mark.cloud
+@pytest.mark.parametrize("compute_arrays_in_parallel", [True, False])
+def test_compute_arrays_in_parallel_modal(modal_executor, compute_arrays_in_parallel):
+    from cubed.runtime.executors.modal_async import AsyncModalDagExecutor
+
+    if not isinstance(modal_executor, AsyncModalDagExecutor):
+        pytest.skip(
+            f"{type(modal_executor)} does not support compute_arrays_in_parallel"
+        )
+
+    tmp_path = "s3://cubed-unittest/parallel_pipelines"
+    spec = cubed.Spec(tmp_path, allowed_mem=100000)
+    try:
+        a = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
+        b = cubed.random.random((10, 10), chunks=(5, 5), spec=spec)
+        c = xp.add(a, b)
+
+        # note that this merely checks that compute_arrays_in_parallel is accepted
+        c.compute(
+            executor=modal_executor,
+            compute_arrays_in_parallel=compute_arrays_in_parallel,
+        )
+    finally:
+        fs = fsspec.open(tmp_path).fs
+        fs.rm(tmp_path, recursive=True)
+
+
+@pytest.mark.cloud
+def test_check_runtime_memory_modal(spec, modal_executor):
+    tmp_path = "s3://cubed-unittest/check-runtime-memory"
+    spec = cubed.Spec(tmp_path, allowed_mem="4GB")  # larger than Modal runtime memory
+    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
+    b = xp.asarray([[1, 1, 1], [1, 1, 1], [1, 1, 1]], chunks=(2, 2), spec=spec)
+    c = xp.add(a, b)
+    with pytest.raises(
+        ValueError,
+        match=r"Runtime memory \(2097152000\) is less than allowed_mem \(4000000000\)",
+    ):
+        c.compute(executor=modal_executor)


### PR DESCRIPTION
Moves the logic for async executors into a common function, which can be used for an async Dask Distributed executor later.

Also adds a `batch_size` argument to address #239 for Modal (and Python async).