### PR TITLE
Fix array `__abs__` method for complex inputs

### DIFF
--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -13,6 +13,10 @@ from cubed.array_api.dtypes import (
     _integer_dtypes,
     _integer_or_boolean_dtypes,
     _numeric_dtypes,
+    complex64,
+    complex128,
+    float32,
+    float64,
 )
 from cubed.array_api.linear_algebra_functions import matmul
 from cubed.core.array import CoreArray
@@ -337,7 +341,13 @@ class Array(CoreArray):
     def __abs__(self, /):
         if self.dtype not in _numeric_dtypes:
             raise TypeError("Only numeric dtypes are allowed in __abs__")
-        return elemwise(np.abs, self, dtype=self.dtype)
+        if self.dtype == complex64:
+            dtype = float32
+        elif self.dtype == complex128:
+            dtype = float64
+        else:
+            dtype = self.dtype
+        return elemwise(np.abs, self, dtype=dtype)
 
     def __array_namespace__(self, /, *, api_version=None):
         if api_version is not None and not api_version.startswith("2021."):


### PR DESCRIPTION
Fixes failure at https://github.com/tomwhite/cubed/actions/runs/5934080650/job/16090423096 by bringing the `__abs__` method implementation into line with the implementation of the `abs` function.

```
FAILED array_api_tests/test_operators_and_elementwise_functions.py::test_abs[__abs__] - AssertionError: assert dtype('complex64') == dtype('float32')
 +  where dtype('complex64') = cubed.Array<array-943, shape=(0,), dtype=complex64, chunks=((0,),)>.dtype
Falsifying example: test_abs(
    ctx=UnaryParamContext(<__abs__>),
    data=data(...),
)
Draw 1 (x): cubed.Array<array-942, shape=(0,), dtype=complex64, chunks=((0,),)>

You can reproduce this example by temporarily adding @reproduce_failure('6.82.6', b'AAoBAAA=') as a decorator on your test case
```