### PR TITLE
Fix bug when running with Kerchunk

### DIFF
--- a/cubed/utils.py
+++ b/cubed/utils.py
@@ -177,8 +177,7 @@ def extract_array_names(frame):
             array_names_to_variable_names[arr.name] = var
         elif (
             type(arr).__module__.split(".")[0] == "xarray"
-            and hasattr(arr, "data")
-            and hasattr(arr, "name")
+            and arr.__class__.__name__ == "DataArray"
         ):
             if isinstance(arr.data, Array):
                 array_names_to_variable_names[arr.data.name] = arr.name


### PR DESCRIPTION
This change allows Cubed to read a kerchunk-ed dataset. See https://github.com/xarray-contrib/cubed-xarray/issues/7

Without this fix the code will attempt to materialize the `data` instance variable of Xarray `Variable` types, when `hasattr(arr, "data")` is called. This change makes the check for Cubed arrays in Xarray `DataArray`s explicit.