### PR TITLE
Remove limited implementation of `__setitem__` from `Array`

### DIFF
--- a/cubed/core/array.py
+++ b/cubed/core/array.py
@@ -6,7 +6,6 @@ from warnings import warn
 import numpy as np
 from toolz import map, reduce
 
-from cubed.runtime.pipeline import already_computed
 from cubed.runtime.types import Executor
 from cubed.storage.zarr import open_if_lazy_zarr_array
 from cubed.utils import chunk_memory, convert_to_bytes
@@ -190,20 +189,6 @@ class CoreArray:
         from cubed.core.ops import index
 
         return index(self, key)
-
-    def __setitem__(self, key, value):
-        if isinstance(value, CoreArray) and value.ndim != 0:
-            raise NotImplementedError(
-                "Calling __setitem__ on an array with more than 0 dimensions is not supported."
-            )
-
-        nodes = {n: d for (n, d) in self.plan.dag.nodes(data=True)}
-        if not already_computed(nodes[self.name]):
-            raise NotImplementedError(
-                "Calling __setitem__ on an array that has not been computed is not supported."
-            )
-
-        self.zarray.__setitem__(key, value)
 
     def __repr__(self):
         return f"cubed.core.CoreArray<{self.name}, shape={self.shape}, dtype={self.dtype}, chunks={self.chunks}>"

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -277,28 +277,6 @@ def test_index_slice_unsupported_step(spec):
         a[::-1]
 
 
-@pytest.mark.xfail(reason="not currently compatible with lazy zarr arrays")
-def test_setitem(spec):
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.ones(())
-    a[1, 2] = b
-    assert_array_equal(a.compute(), np.array([[1, 2, 3], [4, 5, 1], [7, 8, 9]]))
-
-
-def test_setitem_fails_not_0d(spec):
-    a = xp.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], chunks=(2, 2), spec=spec)
-    b = xp.asarray([[4, 5, 6], [7, 8, 9], [1, 2, 3]], chunks=(2, 2), spec=spec)
-    with pytest.raises(NotImplementedError):
-        a[:] = b
-
-
-def test_setitem_fails_not_computed(spec):
-    a = xp.arange(12, chunks=(4,), spec=spec)
-    b = xp.ones(())
-    with pytest.raises(NotImplementedError):
-        a[1] = b
-
-
 @pytest.mark.parametrize("axis", [0, 1])
 def test_take(spec, axis):
     a = xp.asarray(


### PR DESCRIPTION
I originally added a very limited form of `__setitem__` that only accepts single element updates to support the Array API tests, that needed it at the time. Now this is no longer a requirement (https://hypothesis.readthedocs.io/en/latest/changes.html#v6-75-8), I propose removing the code since it isn't generally useful.

With this change we'd be able to treat arrays as immutable, which opens up more optimizations, such as making `full` a "virtual" (non-materialized) array (see #290, #247).

Also, if we decide we need to make arrays mutable in the future, we can do that in a more intentional way - perhaps by marking any mutated arrays as needing to be materialized to Zarr, so they can then be mutated.