### PR TITLE
Update Coiled example

### DIFF
--- a/cubed/runtime/executors/coiled.py
+++ b/cubed/runtime/executors/coiled.py
@@ -1,20 +1,16 @@
 from typing import Any, Mapping, Optional, Sequence
 
 import coiled
-from dask.distributed import as_completed
 from networkx import MultiDiGraph
 
-from cubed.core.array import Callback
+from cubed.core.array import Callback, Spec
 from cubed.core.plan import visit_nodes
 from cubed.runtime.types import DagExecutor
 from cubed.runtime.utils import execution_stats, handle_callbacks
 
 
-def exec_stage_func(func, m, coiled_kwargs, **kwargs):
-    # TODO would be good to give the dask tasks useful names
-
-    # coiled_kwargs are tokenized by coiled.run, so each stage will reconnect to same cluster
-    return coiled.run(**coiled_kwargs)(execution_stats(func)).submit(m, **kwargs)
+def make_coiled_function(func, coiled_kwargs):
+    return coiled.function(**coiled_kwargs)(execution_stats(func))
 
 
 class CoiledFunctionsDagExecutor(DagExecutor):
@@ -26,23 +22,18 @@ class CoiledFunctionsDagExecutor(DagExecutor):
         callbacks: Optional[Sequence[Callback]] = None,
         array_names: Optional[Sequence[str]] = None,
         resume: Optional[bool] = None,
+        spec: Optional[Spec] = None,
         **coiled_kwargs: Mapping[str, Any],
     ) -> None:
         # Note this currently only builds the task graph for each stage once it gets to that stage in computation
         for name, node in visit_nodes(dag, resume=resume):
             pipeline = node["pipeline"]
-            futures = []
-            for m in pipeline.mappable:
-                future_func = exec_stage_func(
-                    pipeline.function, m, coiled_kwargs, config=pipeline.config
-                )
-                futures.append(future_func)
-
-            # gather the results of the coiled functions
-            ac = as_completed(futures)
-            if callbacks is not None:
-                for future in ac:
-                    result, stats = future.result()
+            coiled_function = make_coiled_function(pipeline.function, coiled_kwargs)
+            input = list(
+                pipeline.mappable
+            )  # coiled expects a sequence (it calls `len` on it)
+            for _, stats in coiled_function.map(input, config=pipeline.config):
+                if callbacks is not None:
                     if name is not None:
                         stats["array_name"] = name
                     handle_callbacks(callbacks, stats)

--- a/examples/coiled/aws/README.md
+++ b/examples/coiled/aws/README.md
@@ -26,3 +26,9 @@ python coiled-add-asarray.py "s3://cubed-$USER-temp"
 ```
 
 If successful it should print a 4x4 matrix.
+
+Run the other example in a similar way
+
+```shell
+python coiled-add-random.py "s3://cubed-modal-$USER-temp"
+```

--- a/examples/coiled/aws/README.md
+++ b/examples/coiled/aws/README.md
@@ -8,14 +8,13 @@
 ## Set up
 
 1. Save your aws credentials in a ``~/.aws/credentials`` file locally, following [Coiled's instructions on accessing remote data](https://docs.coiled.io/user_guide/remote-data-access.html).
-2. Create a new S3 bucket (called `cubed-<username>-temp`, for example) in the `us-east-1` region. This will be used for intermediate data.
+2. Create a new S3 bucket (called `cubed-<username>-temp`, for example) in the same region as your Coiled account (e.g. `us-east-1`). This will be used for intermediate data.
 3. Install a Python environment with the coiled package in it by running the following from this directory:
 
 ```shell
 conda create --name cubed-coiled-examples -y python=3.8
 conda activate cubed-coiled-examples
 pip install 'cubed[coiled]'
-export CUBED_COILED_REQUIREMENTS_FILE=$(pwd)/requirements.txt
 ```
 
 ## Examples

--- a/examples/coiled/aws/coiled-add-asarray.py
+++ b/examples/coiled/aws/coiled-add-asarray.py
@@ -22,7 +22,8 @@ if __name__ == "__main__":
     res = c.compute(
         executor=executor,
         memory="1 GiB",  # must be greater than allowed_mem
-        compute_purchase_option="spot_with_fallback",  # recommended
-        account="dask",  # dask maintainers account - change this to your account
+        spot_policy="spot_with_fallback",  # recommended
+        account=None,  # use your default account (or change to use a specific account)
+        keepalive="30 seconds",  # change this to keep clusters alive longer
     )
     print(res)

--- a/examples/coiled/aws/coiled-add-random.py
+++ b/examples/coiled/aws/coiled-add-random.py
@@ -1,0 +1,36 @@
+import sys
+
+import cubed
+import cubed.array_api as xp
+import cubed.random
+from cubed.extensions.history import HistoryCallback
+from cubed.extensions.timeline import TimelineVisualizationCallback
+from cubed.extensions.tqdm import TqdmProgressBar, std_out_err_redirect_tqdm
+from cubed.runtime.executors.coiled import CoiledFunctionsDagExecutor
+
+if __name__ == "__main__":
+    tmp_path = sys.argv[1]
+    spec = cubed.Spec(tmp_path, allowed_mem=2_000_000_000)
+    executor = CoiledFunctionsDagExecutor()
+    a = cubed.random.random(
+        (50000, 50000), chunks=(5000, 5000), spec=spec
+    )  # 200MB chunks
+    b = cubed.random.random(
+        (50000, 50000), chunks=(5000, 5000), spec=spec
+    )  # 200MB chunks
+    c = xp.add(a, b)
+    with std_out_err_redirect_tqdm() as orig_stdout:
+        progress = TqdmProgressBar(file=orig_stdout, dynamic_ncols=True)
+        hist = HistoryCallback()
+        timeline_viz = TimelineVisualizationCallback()
+        # use store=None to write to temporary zarr
+        cubed.to_zarr(
+            c,
+            store=None,
+            executor=executor,
+            callbacks=[progress, hist, timeline_viz],
+            memory="2 GiB",  # must be at least allowed_mem
+            spot_policy="spot_with_fallback",  # recommended
+            account=None,  # use your default account (or change to use a specific account)
+            keepalive="30 seconds",  # change this to keep clusters alive longer
+        )


### PR DESCRIPTION
I tried running the Coiled example today and found that it needed some updates.

The name of `coiled.run` has changed to `coiled.function`, and some of the parameters have changed. This PR fixes that, and makes a few other simplifications/changes.

Also, I noticed that the scaling up when running a bigger example (`coiled-add-random.py`) wasn't what I expected - it scaled first to 3 then later to 6 instances. The 3 was probably because there were 3 tasks in the first stage. The second stage had 100 tasks.

I wonder if we could [adpaptively scale](https://docs.coiled.io/user_guide/usage/functions/index.html#adaptive-scaling) to the maximum number of tasks for any stage of a plan before starting the computation? (Or maybe a fraction of that number.)