### PR TITLE
Array API backend

### DIFF
--- a/cubed/array_api/array_object.py
+++ b/cubed/array_api/array_object.py
@@ -19,6 +19,7 @@ from cubed.array_api.dtypes import (
     float64,
 )
 from cubed.array_api.linear_algebra_functions import matmul
+from cubed.backend_array_api import namespace as nxp
 from cubed.core.array import CoreArray
 from cubed.core.ops import elemwise
 from cubed.utils import memory_repr
@@ -118,54 +119,54 @@ class Array(CoreArray):
     def __neg__(self, /):
         if self.dtype not in _numeric_dtypes:
             raise TypeError("Only numeric dtypes are allowed in __neg__")
-        return elemwise(np.negative, self, dtype=self.dtype)
+        return elemwise(nxp.negative, self, dtype=self.dtype)
 
     def __pos__(self, /):
         if self.dtype not in _numeric_dtypes:
             raise TypeError("Only numeric dtypes are allowed in __pos__")
-        return elemwise(np.positive, self, dtype=self.dtype)
+        return elemwise(nxp.positive, self, dtype=self.dtype)
 
     def __add__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__add__")
         if other is NotImplemented:
             return other
-        return elemwise(np.add, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.add, self, other, dtype=result_type(self, other))
 
     def __sub__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__sub__")
         if other is NotImplemented:
             return other
-        return elemwise(np.subtract, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.subtract, self, other, dtype=result_type(self, other))
 
     def __mul__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__mul__")
         if other is NotImplemented:
             return other
-        return elemwise(np.multiply, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.multiply, self, other, dtype=result_type(self, other))
 
     def __truediv__(self, other, /):
         other = self._check_allowed_dtypes(other, "floating-point", "__truediv__")
         if other is NotImplemented:
             return other
-        return elemwise(np.divide, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.divide, self, other, dtype=result_type(self, other))
 
     def __floordiv__(self, other, /):
         other = self._check_allowed_dtypes(other, "real numeric", "__floordiv__")
         if other is NotImplemented:
             return other
-        return elemwise(np.floor_divide, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.floor_divide, self, other, dtype=result_type(self, other))
 
     def __mod__(self, other, /):
         other = self._check_allowed_dtypes(other, "real numeric", "__mod__")
         if other is NotImplemented:
             return other
-        return elemwise(np.remainder, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.remainder, self, other, dtype=result_type(self, other))
 
     def __pow__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__pow__")
         if other is NotImplemented:
             return other
-        return elemwise(np.power, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.pow, self, other, dtype=result_type(self, other))
 
     # Array Operators
 
@@ -180,37 +181,41 @@ class Array(CoreArray):
     def __invert__(self, /):
         if self.dtype not in _integer_or_boolean_dtypes:
             raise TypeError("Only integer or boolean dtypes are allowed in __invert__")
-        return elemwise(np.invert, self, dtype=self.dtype)
+        return elemwise(nxp.bitwise_invert, self, dtype=self.dtype)
 
     def __and__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__and__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_and, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_and, self, other, dtype=result_type(self, other))
 
     def __or__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__or__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_or, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_or, self, other, dtype=result_type(self, other))
 
     def __xor__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__xor__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_xor, self, other, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_xor, self, other, dtype=result_type(self, other))
 
     def __lshift__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer", "__lshift__")
         if other is NotImplemented:
             return other
-        return elemwise(np.left_shift, self, other, dtype=result_type(self, other))
+        return elemwise(
+            nxp.bitwise_left_shift, self, other, dtype=result_type(self, other)
+        )
 
     def __rshift__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer", "__rshift__")
         if other is NotImplemented:
             return other
-        return elemwise(np.right_shift, self, other, dtype=result_type(self, other))
+        return elemwise(
+            nxp.bitwise_right_shift, self, other, dtype=result_type(self, other)
+        )
 
     # Comparison Operators
 
@@ -218,37 +223,37 @@ class Array(CoreArray):
         other = self._check_allowed_dtypes(other, "all", "__eq__")
         if other is NotImplemented:
             return other
-        return elemwise(np.equal, self, other, dtype=np.bool_)
+        return elemwise(nxp.equal, self, other, dtype=np.bool_)
 
     def __ge__(self, other, /):
         other = self._check_allowed_dtypes(other, "all", "__ge__")
         if other is NotImplemented:
             return other
-        return elemwise(np.greater_equal, self, other, dtype=np.bool_)
+        return elemwise(nxp.greater_equal, self, other, dtype=np.bool_)
 
     def __gt__(self, other, /):
         other = self._check_allowed_dtypes(other, "all", "__gt__")
         if other is NotImplemented:
             return other
-        return elemwise(np.greater, self, other, dtype=np.bool_)
+        return elemwise(nxp.greater, self, other, dtype=np.bool_)
 
     def __le__(self, other, /):
         other = self._check_allowed_dtypes(other, "all", "__le__")
         if other is NotImplemented:
             return other
-        return elemwise(np.less_equal, self, other, dtype=np.bool_)
+        return elemwise(nxp.less_equal, self, other, dtype=np.bool_)
 
     def __lt__(self, other, /):
         other = self._check_allowed_dtypes(other, "all", "__lt__")
         if other is NotImplemented:
             return other
-        return elemwise(np.less, self, other, dtype=np.bool_)
+        return elemwise(nxp.less, self, other, dtype=np.bool_)
 
     def __ne__(self, other, /):
         other = self._check_allowed_dtypes(other, "all", "__ne__")
         if other is NotImplemented:
             return other
-        return elemwise(np.not_equal, self, other, dtype=np.bool_)
+        return elemwise(nxp.not_equal, self, other, dtype=np.bool_)
 
     # Reflected Operators
 
@@ -258,43 +263,43 @@ class Array(CoreArray):
         other = self._check_allowed_dtypes(other, "numeric", "__radd__")
         if other is NotImplemented:
             return other
-        return elemwise(np.add, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.add, other, self, dtype=result_type(self, other))
 
     def __rsub__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__rsub__")
         if other is NotImplemented:
             return other
-        return elemwise(np.subtract, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.subtract, other, self, dtype=result_type(self, other))
 
     def __rmul__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__rmul__")
         if other is NotImplemented:
             return other
-        return elemwise(np.multiply, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.multiply, other, self, dtype=result_type(self, other))
 
     def __rtruediv__(self, other, /):
         other = self._check_allowed_dtypes(other, "floating-point", "__rtruediv__")
         if other is NotImplemented:
             return other
-        return elemwise(np.divide, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.divide, other, self, dtype=result_type(self, other))
 
     def __rfloordiv__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__rfloordiv__")
         if other is NotImplemented:
             return other
-        return elemwise(np.floor_divide, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.floor_divide, other, self, dtype=result_type(self, other))
 
     def __rmod__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__rmod__")
         if other is NotImplemented:
             return other
-        return elemwise(np.remainder, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.remainder, other, self, dtype=result_type(self, other))
 
     def __rpow__(self, other, /):
         other = self._check_allowed_dtypes(other, "numeric", "__rpow__")
         if other is NotImplemented:
             return other
-        return elemwise(np.power, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.pow, other, self, dtype=result_type(self, other))
 
     # (Reflected) Array Operators
 
@@ -310,31 +315,35 @@ class Array(CoreArray):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__rand__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_and, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_and, other, self, dtype=result_type(self, other))
 
     def __ror__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__ror__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_or, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_or, other, self, dtype=result_type(self, other))
 
     def __rxor__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer or boolean", "__rxor__")
         if other is NotImplemented:
             return other
-        return elemwise(np.bitwise_xor, other, self, dtype=result_type(self, other))
+        return elemwise(nxp.bitwise_xor, other, self, dtype=result_type(self, other))
 
     def __rlshift__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer", "__rlshift__")
         if other is NotImplemented:
             return other
-        return elemwise(np.left_shift, other, self, dtype=result_type(self, other))
+        return elemwise(
+            nxp.bitwise_left_shift, other, self, dtype=result_type(self, other)
+        )
 
     def __rrshift__(self, other, /):
         other = self._check_allowed_dtypes(other, "integer", "__rrshift__")
         if other is NotImplemented:
             return other
-        return elemwise(np.right_shift, other, self, dtype=result_type(self, other))
+        return elemwise(
+            nxp.bitwise_right_shift, other, self, dtype=result_type(self, other)
+        )
 
     # Methods
 
@@ -347,7 +356,7 @@ class Array(CoreArray):
             dtype = float64
         else:
             dtype = self.dtype
-        return elemwise(np.abs, self, dtype=dtype)
+        return elemwise(nxp.abs, self, dtype=dtype)
 
     def __array_namespace__(self, /, *, api_version=None):
         if api_version is not None and not api_version.startswith("2021."):

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -1,3 +1,4 @@
+import math
 from typing import TYPE_CHECKING, Iterable, List
 
 import numpy as np
@@ -20,7 +21,7 @@ def arange(
 ) -> "Array":
     if stop is None:
         start, stop = 0, start
-    num = int(max(np.ceil((stop - start) / step), 0))
+    num = int(max(math.ceil((stop - start) / step), 0))
     if dtype is None:
         dtype = np.arange(start, stop, step * num if num else step).dtype
     chunks = normalize_chunks(chunks, shape=(num,), dtype=dtype)

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Iterable, List
 import numpy as np
 from zarr.util import normalize_shape
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import Plan, gensym, map_blocks
 from cubed.core.ops import map_direct
 from cubed.core.plan import new_temp_path
@@ -23,7 +24,7 @@ def arange(
         start, stop = 0, start
     num = int(max(math.ceil((stop - start) / step), 0))
     if dtype is None:
-        dtype = np.arange(start, stop, step * num if num else step).dtype
+        dtype = nxp.arange(start, stop, step * num if num else step).dtype
     chunks = normalize_chunks(chunks, shape=(num,), dtype=dtype)
     chunksize = chunks[0][0]
     numblocks = len(chunks[0])
@@ -47,7 +48,7 @@ def _arange(a, size, start, stop, step):
     i = int(a[0])
     blockstart = start + (i * size * step)
     blockstop = start + ((i + 1) * size * step)
-    return np.arange(blockstart, min(blockstop, stop), step)
+    return nxp.arange(blockstart, min(blockstop, stop), step)
 
 
 def asarray(
@@ -65,7 +66,7 @@ def asarray(
         return asarray(a.data)
     elif not isinstance(getattr(a, "shape", None), Iterable):
         # ensure blocks are arrays
-        a = np.asarray(a, dtype=dtype)
+        a = nxp.asarray(a, dtype=dtype)
     if dtype is None:
         dtype = a.dtype
 
@@ -134,9 +135,9 @@ def _eye(x, *arrays, k=None, chunksize=None, block_id=None):
     i, j = block_id
     bk = (j - i) * chunksize
     if bk - chunksize <= k <= bk + chunksize:
-        return np.eye(x.shape[0], x.shape[1], k=k - bk, dtype=x.dtype)
+        return nxp.eye(x.shape[0], x.shape[1], k=k - bk, dtype=x.dtype)
     else:
-        return np.zeros_like(x)
+        return nxp.zeros_like(x)
 
 
 def full(
@@ -226,7 +227,7 @@ def _linspace(x, *arrays, size, start, step, endpoint, linspace_dtype, block_id=
     adjusted_bs = bs - 1 if endpoint else bs
     blockstart = start + (i * size * step)
     blockstop = blockstart + (adjusted_bs * step)
-    return np.linspace(
+    return nxp.linspace(
         blockstart, blockstop, bs, endpoint=endpoint, dtype=linspace_dtype
     )
 

--- a/cubed/array_api/creation_functions.py
+++ b/cubed/array_api/creation_functions.py
@@ -43,7 +43,7 @@ def arange(
 
 
 def _arange(a, size, start, stop, step):
-    i = a[0]
+    i = int(a[0])
     blockstart = start + (i * size * step)
     blockstop = start + ((i + 1) * size * step)
     return np.arange(blockstart, min(blockstop, stop), step)

--- a/cubed/array_api/data_type_functions.py
+++ b/cubed/array_api/data_type_functions.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.array_api._typing import Dtype
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import CoreArray, map_blocks
 
 from .dtypes import (
@@ -25,7 +26,7 @@ def astype(x, dtype, /, *, copy=True):
 
 
 def _astype(a, astype_dtype):
-    return a.astype(astype_dtype)
+    return nxp.astype(a, astype_dtype)
 
 
 def can_cast(from_, to, /):

--- a/cubed/array_api/elementwise_functions.py
+++ b/cubed/array_api/elementwise_functions.py
@@ -15,6 +15,7 @@ from cubed.array_api.dtypes import (
     float32,
     float64,
 )
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import elemwise
 
 
@@ -27,55 +28,55 @@ def abs(x, /):
         dtype = float64
     else:
         dtype = x.dtype
-    return elemwise(np.abs, x, dtype=dtype)
+    return elemwise(nxp.abs, x, dtype=dtype)
 
 
 def acos(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in acos")
-    return elemwise(np.arccos, x, dtype=x.dtype)
+    return elemwise(nxp.acos, x, dtype=x.dtype)
 
 
 def acosh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in acosh")
-    return elemwise(np.arccosh, x, dtype=x.dtype)
+    return elemwise(nxp.acosh, x, dtype=x.dtype)
 
 
 def add(x1, x2, /):
     if x1.dtype not in _numeric_dtypes or x2.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in add")
-    return elemwise(np.add, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.add, x1, x2, dtype=result_type(x1, x2))
 
 
 def asin(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in asin")
-    return elemwise(np.arcsin, x, dtype=x.dtype)
+    return elemwise(nxp.asin, x, dtype=x.dtype)
 
 
 def asinh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in asinh")
-    return elemwise(np.arcsinh, x, dtype=x.dtype)
+    return elemwise(nxp.asinh, x, dtype=x.dtype)
 
 
 def atan(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in atan")
-    return elemwise(np.arctan, x, dtype=x.dtype)
+    return elemwise(nxp.atan, x, dtype=x.dtype)
 
 
 def atan2(x1, x2, /):
     if x1.dtype not in _real_floating_dtypes or x2.dtype not in _real_floating_dtypes:
         raise TypeError("Only real floating-point dtypes are allowed in atan2")
-    return elemwise(np.arctan2, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.atan2, x1, x2, dtype=result_type(x1, x2))
 
 
 def atanh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in atanh")
-    return elemwise(np.arctanh, x, dtype=x.dtype)
+    return elemwise(nxp.atanh, x, dtype=x.dtype)
 
 
 def bitwise_and(x1, x2, /):
@@ -84,19 +85,19 @@ def bitwise_and(x1, x2, /):
         or x2.dtype not in _integer_or_boolean_dtypes
     ):
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_and")
-    return elemwise(np.bitwise_and, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.bitwise_and, x1, x2, dtype=result_type(x1, x2))
 
 
 def bitwise_invert(x, /):
     if x.dtype not in _integer_or_boolean_dtypes:
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_invert")
-    return elemwise(np.invert, x, dtype=x.dtype)
+    return elemwise(nxp.bitwise_invert, x, dtype=x.dtype)
 
 
 def bitwise_left_shift(x1, x2, /):
     if x1.dtype not in _integer_dtypes or x2.dtype not in _integer_dtypes:
         raise TypeError("Only integer dtypes are allowed in bitwise_left_shift")
-    return elemwise(np.left_shift, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.bitwise_left_shift, x1, x2, dtype=result_type(x1, x2))
 
 
 def bitwise_or(x1, x2, /):
@@ -105,13 +106,13 @@ def bitwise_or(x1, x2, /):
         or x2.dtype not in _integer_or_boolean_dtypes
     ):
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_or")
-    return elemwise(np.bitwise_or, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.bitwise_or, x1, x2, dtype=result_type(x1, x2))
 
 
 def bitwise_right_shift(x1, x2, /):
     if x1.dtype not in _integer_dtypes or x2.dtype not in _integer_dtypes:
         raise TypeError("Only integer dtypes are allowed in bitwise_right_shift")
-    return elemwise(np.right_shift, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.bitwise_right_shift, x1, x2, dtype=result_type(x1, x2))
 
 
 def bitwise_xor(x1, x2, /):
@@ -120,7 +121,7 @@ def bitwise_xor(x1, x2, /):
         or x2.dtype not in _integer_or_boolean_dtypes
     ):
         raise TypeError("Only integer or boolean dtypes are allowed in bitwise_xor")
-    return elemwise(np.bitwise_xor, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.bitwise_xor, x1, x2, dtype=result_type(x1, x2))
 
 
 def ceil(x, /):
@@ -129,47 +130,47 @@ def ceil(x, /):
     if x.dtype in _integer_dtypes:
         # Note: The return dtype of ceil is the same as the input
         return x
-    return elemwise(np.ceil, x, dtype=x.dtype)
+    return elemwise(nxp.ceil, x, dtype=x.dtype)
 
 
 def conj(x, /):
     if x.dtype not in _complex_floating_dtypes:
         raise TypeError("Only complex floating-point dtypes are allowed in conj")
-    return elemwise(np.conj, x, dtype=x.dtype)
+    return elemwise(nxp.conj, x, dtype=x.dtype)
 
 
 def cos(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in cos")
-    return elemwise(np.cos, x, dtype=x.dtype)
+    return elemwise(nxp.cos, x, dtype=x.dtype)
 
 
 def cosh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in cosh")
-    return elemwise(np.cosh, x, dtype=x.dtype)
+    return elemwise(nxp.cosh, x, dtype=x.dtype)
 
 
 def divide(x1, x2, /):
     if x1.dtype not in _floating_dtypes or x2.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in divide")
-    return elemwise(np.divide, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.divide, x1, x2, dtype=result_type(x1, x2))
 
 
 def exp(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in exp")
-    return elemwise(np.exp, x, dtype=x.dtype)
+    return elemwise(nxp.exp, x, dtype=x.dtype)
 
 
 def expm1(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in expm1")
-    return elemwise(np.expm1, x, dtype=x.dtype)
+    return elemwise(nxp.expm1, x, dtype=x.dtype)
 
 
 def equal(x1, x2, /):
-    return elemwise(np.equal, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.equal, x1, x2, dtype=np.bool_)
 
 
 def floor(x, /):
@@ -178,21 +179,21 @@ def floor(x, /):
     if x.dtype in _integer_dtypes:
         # Note: The return dtype of floor is the same as the input
         return x
-    return elemwise(np.floor, x, dtype=x.dtype)
+    return elemwise(nxp.floor, x, dtype=x.dtype)
 
 
 def floor_divide(x1, x2, /):
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in floor_divide")
-    return elemwise(np.floor_divide, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.floor_divide, x1, x2, dtype=result_type(x1, x2))
 
 
 def greater(x1, x2, /):
-    return elemwise(np.greater, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.greater, x1, x2, dtype=np.bool_)
 
 
 def greater_equal(x1, x2, /):
-    return elemwise(np.greater_equal, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.greater_equal, x1, x2, dtype=np.bool_)
 
 
 def imag(x, /):
@@ -202,115 +203,115 @@ def imag(x, /):
         dtype = float64
     else:
         raise TypeError("Only complex floating-point dtypes are allowed in imag")
-    return elemwise(np.imag, x, dtype=dtype)
+    return elemwise(nxp.imag, x, dtype=dtype)
 
 
 def isfinite(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in isfinite")
-    return elemwise(np.isfinite, x, dtype=np.bool_)
+    return elemwise(nxp.isfinite, x, dtype=np.bool_)
 
 
 def isinf(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in isinf")
-    return elemwise(np.isinf, x, dtype=np.bool_)
+    return elemwise(nxp.isinf, x, dtype=np.bool_)
 
 
 def isnan(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in isnan")
-    return elemwise(np.isnan, x, dtype=np.bool_)
+    return elemwise(nxp.isnan, x, dtype=np.bool_)
 
 
 def less(x1, x2, /):
-    return elemwise(np.less, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.less, x1, x2, dtype=np.bool_)
 
 
 def less_equal(x1, x2, /):
-    return elemwise(np.less_equal, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.less_equal, x1, x2, dtype=np.bool_)
 
 
 def log(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in log")
-    return elemwise(np.log, x, dtype=x.dtype)
+    return elemwise(nxp.log, x, dtype=x.dtype)
 
 
 def log1p(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in log1p")
-    return elemwise(np.log1p, x, dtype=x.dtype)
+    return elemwise(nxp.log1p, x, dtype=x.dtype)
 
 
 def log2(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in log2")
-    return elemwise(np.log2, x, dtype=x.dtype)
+    return elemwise(nxp.log2, x, dtype=x.dtype)
 
 
 def log10(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in log10")
-    return elemwise(np.log10, x, dtype=x.dtype)
+    return elemwise(nxp.log10, x, dtype=x.dtype)
 
 
 def logaddexp(x1, x2, /):
     if x1.dtype not in _real_floating_dtypes or x2.dtype not in _real_floating_dtypes:
         raise TypeError("Only real floating-point dtypes are allowed in logaddexp")
-    return elemwise(np.logaddexp, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.logaddexp, x1, x2, dtype=result_type(x1, x2))
 
 
 def logical_and(x1, x2, /):
     if x1.dtype not in _boolean_dtypes or x2.dtype not in _boolean_dtypes:
         raise TypeError("Only boolean dtypes are allowed in logical_and")
-    return elemwise(np.logical_and, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.logical_and, x1, x2, dtype=np.bool_)
 
 
 def logical_not(x, /):
     if x.dtype not in _boolean_dtypes:
         raise TypeError("Only boolean dtypes are allowed in logical_not")
-    return elemwise(np.logical_not, x, dtype=np.bool_)
+    return elemwise(nxp.logical_not, x, dtype=np.bool_)
 
 
 def logical_or(x1, x2, /):
     if x1.dtype not in _boolean_dtypes or x2.dtype not in _boolean_dtypes:
         raise TypeError("Only boolean dtypes are allowed in logical_or")
-    return elemwise(np.logical_or, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.logical_or, x1, x2, dtype=np.bool_)
 
 
 def logical_xor(x1, x2, /):
     if x1.dtype not in _boolean_dtypes or x2.dtype not in _boolean_dtypes:
         raise TypeError("Only boolean dtypes are allowed in logical_xor")
-    return elemwise(np.logical_xor, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.logical_xor, x1, x2, dtype=np.bool_)
 
 
 def multiply(x1, x2, /):
     if x1.dtype not in _numeric_dtypes or x2.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in multiply")
-    return elemwise(np.multiply, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.multiply, x1, x2, dtype=result_type(x1, x2))
 
 
 def negative(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in negative")
-    return elemwise(np.negative, x, dtype=x.dtype)
+    return elemwise(nxp.negative, x, dtype=x.dtype)
 
 
 def not_equal(x1, x2, /):
-    return elemwise(np.not_equal, x1, x2, dtype=np.bool_)
+    return elemwise(nxp.not_equal, x1, x2, dtype=np.bool_)
 
 
 def positive(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in positive")
-    return elemwise(np.positive, x, dtype=x.dtype)
+    return elemwise(nxp.positive, x, dtype=x.dtype)
 
 
 def pow(x1, x2, /):
     if x1.dtype not in _numeric_dtypes or x2.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in pow")
-    return elemwise(np.power, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.pow, x1, x2, dtype=result_type(x1, x2))
 
 
 def real(x, /):
@@ -320,67 +321,67 @@ def real(x, /):
         dtype = float64
     else:
         raise TypeError("Only complex floating-point dtypes are allowed in real")
-    return elemwise(np.real, x, dtype=dtype)
+    return elemwise(nxp.real, x, dtype=dtype)
 
 
 def remainder(x1, x2, /):
     if x1.dtype not in _real_numeric_dtypes or x2.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in remainder")
-    return elemwise(np.remainder, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.remainder, x1, x2, dtype=result_type(x1, x2))
 
 
 def round(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in round")
-    return elemwise(np.round, x, dtype=x.dtype)
+    return elemwise(nxp.round, x, dtype=x.dtype)
 
 
 def sign(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in sign")
-    return elemwise(np.sign, x, dtype=x.dtype)
+    return elemwise(nxp.sign, x, dtype=x.dtype)
 
 
 def sin(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in sin")
-    return elemwise(np.sin, x, dtype=x.dtype)
+    return elemwise(nxp.sin, x, dtype=x.dtype)
 
 
 def sinh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in sinh")
-    return elemwise(np.sinh, x, dtype=x.dtype)
+    return elemwise(nxp.sinh, x, dtype=x.dtype)
 
 
 def sqrt(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in sqrt")
-    return elemwise(np.sqrt, x, dtype=x.dtype)
+    return elemwise(nxp.sqrt, x, dtype=x.dtype)
 
 
 def square(x, /):
     if x.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in square")
-    return elemwise(np.square, x, dtype=x.dtype)
+    return elemwise(nxp.square, x, dtype=x.dtype)
 
 
 def subtract(x1, x2, /):
     if x1.dtype not in _numeric_dtypes or x2.dtype not in _numeric_dtypes:
         raise TypeError("Only numeric dtypes are allowed in subtract")
-    return elemwise(np.subtract, x1, x2, dtype=result_type(x1, x2))
+    return elemwise(nxp.subtract, x1, x2, dtype=result_type(x1, x2))
 
 
 def tan(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in tan")
-    return elemwise(np.tan, x, dtype=x.dtype)
+    return elemwise(nxp.tan, x, dtype=x.dtype)
 
 
 def tanh(x, /):
     if x.dtype not in _floating_dtypes:
         raise TypeError("Only floating-point dtypes are allowed in tanh")
-    return elemwise(np.tanh, x, dtype=x.dtype)
+    return elemwise(nxp.tanh, x, dtype=x.dtype)
 
 
 def trunc(x, /):
@@ -389,4 +390,4 @@ def trunc(x, /):
     if x.dtype in _integer_dtypes:
         # Note: The return dtype of trunc is the same as the input
         return x
-    return elemwise(np.trunc, x, dtype=x.dtype)
+    return elemwise(nxp.trunc, x, dtype=x.dtype)

--- a/cubed/array_api/linear_algebra_functions.py
+++ b/cubed/array_api/linear_algebra_functions.py
@@ -6,6 +6,7 @@ import numpy as np
 from cubed.array_api.data_type_functions import result_type
 from cubed.array_api.dtypes import _numeric_dtypes
 from cubed.array_api.manipulation_functions import expand_dims
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import blockwise, reduction, squeeze
 
 
@@ -59,7 +60,7 @@ def matmul(x1, x2, /):
 
 
 def _matmul(a, b):
-    chunk = np.matmul(a, b)
+    chunk = nxp.matmul(a, b)
     return chunk[..., np.newaxis, :]
 
 
@@ -71,7 +72,7 @@ def _sum_wo_cat(a, axis=None, dtype=None):
 
 
 def _chunk_sum(a, axis=None, dtype=None, keepdims=None):
-    return np.sum(a, axis=axis, dtype=dtype, keepdims=True)
+    return nxp.sum(a, axis=axis, dtype=dtype, keepdims=True)
 
 
 def matrix_transpose(x, /):
@@ -86,7 +87,7 @@ def matrix_transpose(x, /):
 
 
 def outer(x1, x2, /):
-    return blockwise(np.outer, "ij", x1, "i", x2, "j", dtype=x1.dtype)
+    return blockwise(nxp.linalg.outer, "ij", x1, "i", x2, "j", dtype=x1.dtype)
 
 
 def tensordot(x1, x2, /, *, axes=2):
@@ -137,7 +138,7 @@ def tensordot(x1, x2, /, *, axes=2):
 
 
 def _tensordot(a, b, axes):
-    x = np.tensordot(a, b, axes=axes)
+    x = nxp.tensordot(a, b, axes=axes)
     ind = [slice(None, None)] * x.ndim
     for a in sorted(axes[0]):
         ind.insert(a, None)

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -8,6 +8,7 @@ from toolz import reduce
 
 from cubed.array_api.creation_functions import empty
 from cubed.backend_array_api import namespace as nxp
+from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.core import squeeze  # noqa: F401
 from cubed.core import blockwise, rechunk, unify_chunks
 from cubed.core.ops import elemwise, map_blocks, map_direct
@@ -269,6 +270,7 @@ def _reshape_chunk(e, x, inchunks=None, outchunks=None, block_id=None):
     out_keys = list(product(*[range(len(c)) for c in outchunks]))
     idx = in_keys[out_keys.index(block_id)]
     out = x.zarray[get_item(x.chunks, idx)]
+    out = numpy_array_to_backend_array(out)
     return nxp.reshape(out, e.shape)
 
 

--- a/cubed/array_api/manipulation_functions.py
+++ b/cubed/array_api/manipulation_functions.py
@@ -268,7 +268,7 @@ def _reshape_chunk(e, x, inchunks=None, outchunks=None, block_id=None):
     out_keys = list(product(*[range(len(c)) for c in outchunks]))
     idx = in_keys[out_keys.index(block_id)]
     out = x.zarray[get_item(x.chunks, idx)]
-    return out.reshape(e.shape)
+    return np.reshape(out, e.shape)
 
 
 def stack(arrays, /, *, axis=0):

--- a/cubed/array_api/searching_functions.py
+++ b/cubed/array_api/searching_functions.py
@@ -3,6 +3,7 @@ import numpy as np
 from cubed.array_api.data_type_functions import result_type
 from cubed.array_api.dtypes import _real_numeric_dtypes
 from cubed.array_api.manipulation_functions import reshape
+from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import arg_reduction, elemwise
 
 
@@ -28,4 +29,4 @@ def argmin(x, /, *, axis=None, keepdims=False):
 
 def where(condition, x1, x2, /):
     dtype = result_type(x1, x2)
-    return elemwise(np.where, condition, x1, x2, dtype=dtype)
+    return elemwise(nxp.where, condition, x1, x2, dtype=dtype)

--- a/cubed/array_api/statistical_functions.py
+++ b/cubed/array_api/statistical_functions.py
@@ -15,13 +15,14 @@ from cubed.array_api.dtypes import (
     int64,
     uint64,
 )
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import reduction
 
 
 def max(x, /, *, axis=None, keepdims=False):
     if x.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in max")
-    return reduction(x, np.max, axis=axis, dtype=x.dtype, keepdims=keepdims)
+    return reduction(x, nxp.max, axis=axis, dtype=x.dtype, keepdims=keepdims)
 
 
 def mean(x, /, *, axis=None, keepdims=False):
@@ -52,19 +53,19 @@ def mean(x, /, *, axis=None, keepdims=False):
 def _mean_func(a, **kwargs):
     dtype = dict(kwargs.pop("dtype"))
     n = _numel(a, dtype=dtype["n"], **kwargs)
-    total = np.sum(a, dtype=dtype["total"], **kwargs)
+    total = nxp.sum(a, dtype=dtype["total"], **kwargs)
     return {"n": n, "total": total}
 
 
 def _mean_combine(a, **kwargs):
     dtype = dict(kwargs.pop("dtype"))
-    n = np.sum(a["n"], dtype=dtype["n"], **kwargs)
-    total = np.sum(a["total"], dtype=dtype["total"], **kwargs)
+    n = nxp.sum(a["n"], dtype=dtype["n"], **kwargs)
+    total = nxp.sum(a["total"], dtype=dtype["total"], **kwargs)
     return {"n": n, "total": total}
 
 
 def _mean_aggregate(a):
-    return np.divide(a["total"], a["n"])
+    return nxp.divide(a["total"], a["n"])
 
 
 # based on dask
@@ -82,7 +83,7 @@ def _numel(x, **kwargs):
         if keepdims is False:
             return prod
 
-        return np.full(shape=(1,) * len(shape), fill_value=prod, dtype=dtype)
+        return nxp.full(shape=(1,) * len(shape), fill_value=prod, dtype=dtype)
 
     if not isinstance(axis, (tuple, list)):
         axis = [axis]
@@ -95,13 +96,13 @@ def _numel(x, **kwargs):
     else:
         new_shape = tuple(shape[dim] for dim in range(len(shape)) if dim not in axis)
 
-    return np.broadcast_to(np.array(prod, dtype=dtype), new_shape)
+    return nxp.broadcast_to(nxp.asarray(prod, dtype=dtype), new_shape)
 
 
 def min(x, /, *, axis=None, keepdims=False):
     if x.dtype not in _real_numeric_dtypes:
         raise TypeError("Only real numeric dtypes are allowed in min")
-    return reduction(x, np.min, axis=axis, dtype=x.dtype, keepdims=keepdims)
+    return reduction(x, nxp.min, axis=axis, dtype=x.dtype, keepdims=keepdims)
 
 
 def prod(x, /, *, axis=None, dtype=None, keepdims=False):
@@ -121,7 +122,7 @@ def prod(x, /, *, axis=None, dtype=None, keepdims=False):
     extra_func_kwargs = dict(dtype=dtype)
     return reduction(
         x,
-        np.prod,
+        nxp.prod,
         axis=axis,
         dtype=dtype,
         keepdims=keepdims,
@@ -146,7 +147,7 @@ def sum(x, /, *, axis=None, dtype=None, keepdims=False):
     extra_func_kwargs = dict(dtype=dtype)
     return reduction(
         x,
-        np.sum,
+        nxp.sum,
         axis=axis,
         dtype=dtype,
         keepdims=keepdims,

--- a/cubed/array_api/utility_functions.py
+++ b/cubed/array_api/utility_functions.py
@@ -1,16 +1,15 @@
-import numpy as np
-
 from cubed.array_api.creation_functions import asarray
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import reduction
 
 
 def all(x, /, *, axis=None, keepdims=False):
     if x.size == 0:
         return asarray(True, dtype=x.dtype)
-    return reduction(x, np.all, axis=axis, dtype=bool, keepdims=keepdims)
+    return reduction(x, nxp.all, axis=axis, dtype=bool, keepdims=keepdims)
 
 
 def any(x, /, *, axis=None, keepdims=False):
     if x.size == 0:
         return asarray(False, dtype=x.dtype)
-    return reduction(x, np.any, axis=axis, dtype=bool, keepdims=keepdims)
+    return reduction(x, nxp.any, axis=axis, dtype=bool, keepdims=keepdims)

--- a/cubed/backend_array_api.py
+++ b/cubed/backend_array_api.py
@@ -19,5 +19,5 @@ def backend_array_to_numpy_array(arr):
     return np.asarray(arr)
 
 
-def numpy_array_to_backend_array(arr):
-    return namespace.asarray(arr)
+def numpy_array_to_backend_array(arr, *, dtype=None):
+    return namespace.asarray(arr, dtype=dtype)

--- a/cubed/backend_array_api.py
+++ b/cubed/backend_array_api.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+# The array implementation used for backend operations.
+# This must be compatible with the Python Array API standard, although
+# some extra functions are used too (nan functions, take_along_axis),
+# which array_api_compat provides, but other Array API implementations
+# may not.
+import array_api_compat.numpy  # noqa: F401 isort:skip
+
+namespace = array_api_compat.numpy
+
+# These functions to convert to/from backend arrays
+# assume that no extra memory is allocated, by using the
+# Python buffer protocol.
+# See https://data-apis.org/array-api/latest/API_specification/generated/array_api.asarray.html
+
+
+def backend_array_to_numpy_array(arr):
+    return np.asarray(arr)
+
+
+def numpy_array_to_backend_array(arr):
+    return namespace.asarray(arr)

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -18,6 +18,7 @@ from zarr.indexing import (
 )
 
 from cubed.backend_array_api import namespace as nxp
+from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.core.array import CoreArray, check_array_specs, compute, gensym
 from cubed.core.plan import Plan, new_temp_path
 from cubed.primitive.blockwise import blockwise as primitive_blockwise
@@ -78,6 +79,7 @@ def _from_array(e, x, outchunks=None, asarray=None, block_id=None):
     out = x[get_item(outchunks, block_id)]
     if asarray:
         out = np.asarray(out)
+    out = numpy_array_to_backend_array(out)
     return out
 
 
@@ -419,6 +421,7 @@ def _read_index_chunk(x, *arrays, target_chunks=None, selection=None, block_id=N
     array = arrays[0]
     idx = block_id
     out = array.zarray.oindex[_target_chunk_selection(target_chunks, idx, selection)]
+    out = numpy_array_to_backend_array(out)
     return out
 
 
@@ -704,7 +707,9 @@ def merge_chunks(x, chunks):
 
 
 def _copy_chunk(e, x, target_chunks=None, block_id=None):
-    return x.zarray[get_item(target_chunks, block_id)]
+    out = x.zarray[get_item(target_chunks, block_id)]
+    out = numpy_array_to_backend_array(out)
+    return out
 
 
 def reduction(

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -470,7 +470,8 @@ def map_blocks(
 
         def func_with_block_id(func):
             def wrap(*a, **kw):
-                block_id = offset_to_block_id(a[-1].item())
+                offset = int(a[-1])  # convert from 0-d array
+                block_id = offset_to_block_id(offset)
                 return func(*a[:-1], block_id=block_id, **kw)
 
             return wrap

--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import networkx as nx
 
+from cubed.backend_array_api import backend_array_to_numpy_array
 from cubed.primitive.blockwise import can_fuse_pipelines, fuse
 from cubed.runtime.pipeline import visit_nodes
 from cubed.runtime.types import CubedPipeline
@@ -363,7 +364,8 @@ def create_zarr_arrays(lazy_zarr_arrays, reserved_mem):
     projected_mem = (
         max(
             [
-                lza.initial_values.nbytes
+                # TODO: calculate nbytes from size and dtype itemsize
+                backend_array_to_numpy_array(lza.initial_values).nbytes
                 if lza.initial_values is not None
                 else lza.dtype.itemsize
                 for lza in lazy_zarr_arrays

--- a/cubed/nan_functions.py
+++ b/cubed/nan_functions.py
@@ -11,6 +11,7 @@ from cubed.array_api.dtypes import (
     int64,
     uint64,
 )
+from cubed.backend_array_api import namespace as nxp
 from cubed.core import reduction
 
 # TODO: refactor once nan functions are standardized:
@@ -33,26 +34,29 @@ def nanmean(x, /, *, axis=None, keepdims=False):
     )
 
 
+# note that the array API doesn't have nansum or nanmean, so these functions may fail
+
+
 def _nanmean_func(a, **kwargs):
     n = _nannumel(a, **kwargs)
-    total = np.nansum(a, **kwargs)
+    total = nxp.nansum(a, **kwargs)
     return {"n": n, "total": total}
 
 
 def _nanmean_combine(a, **kwargs):
-    n = np.nansum(a["n"], **kwargs)
-    total = np.nansum(a["total"], **kwargs)
+    n = nxp.nansum(a["n"], **kwargs)
+    total = nxp.nansum(a["total"], **kwargs)
     return {"n": n, "total": total}
 
 
 def _nanmean_aggregate(a):
     with np.errstate(divide="ignore", invalid="ignore"):
-        return np.divide(a["total"], a["n"])
+        return nxp.divide(a["total"], a["n"])
 
 
 def _nannumel(x, **kwargs):
     """A reduction to count the number of elements, excluding nans"""
-    return np.sum(~(np.isnan(x)), **kwargs)
+    return nxp.sum(~(nxp.isnan(x)), **kwargs)
 
 
 def nansum(x, /, *, axis=None, dtype=None, keepdims=False):
@@ -70,4 +74,4 @@ def nansum(x, /, *, axis=None, dtype=None, keepdims=False):
             dtype = complex128
         else:
             dtype = x.dtype
-    return reduction(x, np.nansum, axis=axis, dtype=dtype, keepdims=keepdims)
+    return reduction(x, nxp.nansum, axis=axis, dtype=dtype, keepdims=keepdims)

--- a/cubed/random.py
+++ b/cubed/random.py
@@ -5,6 +5,7 @@ from numpy.random import Generator, Philox
 from zarr.util import normalize_shape
 
 from cubed.backend_array_api import namespace as nxp
+from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.core.ops import map_direct
 from cubed.vendor.dask.array.core import normalize_chunks
 
@@ -36,7 +37,9 @@ def random(size, *, chunks=None, spec=None):
 def _random(x, *arrays, numblocks=None, root_seed=None, block_id=None):
     stream_id = block_id_to_offset(block_id, numblocks)
     rg = Generator(Philox(key=root_seed + stream_id))
-    return rg.random(x.shape)
+    out = rg.random(x.shape)
+    out = numpy_array_to_backend_array(out)
+    return out
 
 
 def block_id_to_offset(block_id, numblocks):

--- a/cubed/random.py
+++ b/cubed/random.py
@@ -1,10 +1,10 @@
 import random as pyrandom
 
 import numpy as np
-import numpy.array_api as nxp
 from numpy.random import Generator, Philox
 from zarr.util import normalize_shape
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import map_direct
 from cubed.vendor.dask.array.core import normalize_chunks
 

--- a/cubed/storage/virtual.py
+++ b/cubed/storage/virtual.py
@@ -5,6 +5,7 @@ import numpy as np
 import zarr
 from zarr.indexing import BasicIndexer, is_slice
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.types import T_DType, T_RegularChunks, T_Shape
 
 
@@ -30,7 +31,7 @@ class VirtualEmptyArray:
         if not isinstance(key, tuple):
             key = (key,)
         indexer = BasicIndexer(key, self.template)
-        return np.empty(indexer.shape, dtype=self.dtype)
+        return nxp.empty(indexer.shape, dtype=self.dtype)
 
     @property
     def oindex(self):
@@ -65,7 +66,7 @@ class VirtualFullArray:
         if not isinstance(key, tuple):
             key = (key,)
         indexer = BasicIndexer(key, self.template)
-        return np.full(indexer.shape, fill_value=self.fill_value, dtype=self.dtype)
+        return nxp.full(indexer.shape, fill_value=self.fill_value, dtype=self.dtype)
 
     @property
     def oindex(self):

--- a/cubed/storage/virtual.py
+++ b/cubed/storage/virtual.py
@@ -6,6 +6,7 @@ import zarr
 from zarr.indexing import BasicIndexer, is_slice
 
 from cubed.backend_array_api import namespace as nxp
+from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.types import T_DType, T_RegularChunks, T_Shape
 
 
@@ -90,8 +91,10 @@ class VirtualOffsetsArray:
 
     def __getitem__(self, key):
         if key == () and self.shape == ():
-            return np.array(0, dtype=self.dtype)
-        return np.ravel_multi_index(_key_to_index_tuple(key), self.shape)
+            return nxp.asarray(0, dtype=self.dtype)
+        return numpy_array_to_backend_array(
+            np.ravel_multi_index(_key_to_index_tuple(key), self.shape), dtype=self.dtype
+        )
 
 
 def _key_to_index_tuple(selection):

--- a/cubed/storage/zarr.py
+++ b/cubed/storage/zarr.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Union
 import zarr
 from numpy import ndarray
 
+from cubed.backend_array_api import backend_array_to_numpy_array
 from cubed.types import T_DType, T_RegularChunks, T_Shape, T_Store
 
 
@@ -60,7 +61,7 @@ class LazyZarrArray:
             **self.kwargs,
         )
         if self.initial_values is not None and self.initial_values.size > 0:
-            target[...] = self.initial_values
+            target[...] = backend_array_to_numpy_array(self.initial_values)
         return target
 
     def open(self) -> zarr.Array:

--- a/cubed/tests/primitive/test_blockwise.py
+++ b/cubed/tests/primitive/test_blockwise.py
@@ -3,6 +3,7 @@ import pytest
 import zarr
 from numpy.testing import assert_array_equal
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.primitive.blockwise import blockwise, make_blockwise_function
 from cubed.runtime.executors.python import PythonDagExecutor
 from cubed.tests.utils import create_zarr, execute_pipeline
@@ -26,7 +27,7 @@ def test_blockwise(tmp_path, executor, reserved_mem):
     target_store = tmp_path / "target.zarr"
 
     pipeline = blockwise(
-        np.outer,
+        nxp.linalg.outer,
         "ij",
         source1,
         "i",
@@ -74,7 +75,7 @@ def _permute_dims(x, /, axes, allowed_mem, reserved_mem, target_store):
         axes = tuple(range(x.ndim))[::-1]
     axes = tuple(d + x.ndim if d < 0 else d for d in axes)
     return blockwise(
-        np.transpose,
+        nxp.permute_dims,
         axes,
         x,
         tuple(range(x.ndim)),
@@ -146,7 +147,7 @@ def test_blockwise_allowed_mem_exceeded(tmp_path, reserved_mem):
         match=r"Projected blockwise memory \(\d+\) exceeds allowed_mem \(100\), including reserved_mem \(\d+\)",
     ):
         blockwise(
-            np.outer,
+            nxp.linalg.outer,
             "ij",
             source1,
             "i",

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_array_equal
 import cubed
 import cubed.array_api as xp
 import cubed.random
+from cubed.backend_array_api import namespace as nxp
 from cubed.core.ops import merge_chunks
 from cubed.tests.utils import (
     ALL_EXECUTORS,
@@ -148,14 +149,14 @@ def test_to_zarr(tmp_path, spec, executor):
 def test_map_blocks_with_kwargs(spec, executor):
     # based on dask test
     a = xp.asarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], chunks=5, spec=spec)
-    b = cubed.map_blocks(np.max, a, axis=0, keepdims=True, dtype=a.dtype, chunks=(1,))
+    b = cubed.map_blocks(nxp.max, a, axis=0, keepdims=True, dtype=a.dtype, chunks=(1,))
     assert_array_equal(b.compute(executor=executor), np.array([4, 9]))
 
 
 def test_map_blocks_with_block_id(spec, executor):
     # based on dask test
     def func(block, block_id=None, c=0):
-        return np.ones_like(block) * int(sum(block_id)) + c
+        return nxp.ones_like(block) * int(sum(block_id)) + c
 
     a = xp.arange(10, dtype="int64", chunks=(2,))
     b = cubed.map_blocks(func, a, dtype="int64")

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -155,7 +155,7 @@ def test_map_blocks_with_kwargs(spec, executor):
 def test_map_blocks_with_block_id(spec, executor):
     # based on dask test
     def func(block, block_id=None, c=0):
-        return np.ones_like(block) * sum(block_id) + c
+        return np.ones_like(block) * int(sum(block_id)) + c
 
     a = xp.arange(10, dtype="int64", chunks=(2,))
     b = cubed.map_blocks(func, a, dtype="int64")

--- a/cubed/tests/test_gufunc.py
+++ b/cubed/tests/test_gufunc.py
@@ -22,7 +22,7 @@ def test_apply_reduction(spec, vectorize):
     r = np.random.normal(size=(10, 20, 30))
     a = cubed.from_array(r, chunks=(5, 5, 30), spec=spec)
     actual = apply_gufunc(stats, "(i)->()", a, output_dtypes="f", vectorize=vectorize)
-    expected = np.mean(r, axis=-1)
+    expected = np.mean(r, axis=-1, dtype=np.float32)
 
     assert actual.compute().shape == expected.shape
     assert_allclose(actual.compute(), expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "aiostream",
+    "array-api-compat",
     "fsspec",
     "mypy_extensions", # for rechunker
     "networkx < 2.8.3",

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ allow_redefinition = True
 ignore_missing_imports = True
 [mypy-aiostream.*]
 ignore_missing_imports = True
+[mypy-array_api_compat.*]
+ignore_missing_imports = True
 [mypy-coiled.*]
 ignore_missing_imports = True
 [mypy-dask.*]


### PR DESCRIPTION
Fixes #315

This uses https://github.com/data-apis/array-api-compat which makes NumPy conform to the array API. There are a couple of places where we use functions not in the array API (which fall back to NumPy): `take_along_axis` for arg reductions, and nan functions.