### PR TITLE
Fix Modal deprecation of `f.call(...)`

### DIFF
--- a/cubed/runtime/executors/modal_async.py
+++ b/cubed/runtime/executors/modal_async.py
@@ -60,7 +60,7 @@ async def map_unordered(
 
     def create_futures_func(input, **kwargs):
         return [
-            (i, asyncio.ensure_future(app_function.call.aio(i, **kwargs)))
+            (i, asyncio.ensure_future(app_function.remote.aio(i, **kwargs)))
             for i in input
         ]
 
@@ -68,7 +68,7 @@ async def map_unordered(
 
     def create_backup_futures_func(input, **kwargs):
         return [
-            (i, asyncio.ensure_future(backup_function.call.aio(i, **kwargs)))
+            (i, asyncio.ensure_future(backup_function.remote.aio(i, **kwargs)))
             for i in input
         ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ ignore =
 exclude = tests|doc
 files = .
 show_error_codes = True
+allow_redefinition = True
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-apache_beam.*]


### PR DESCRIPTION
Failure was (e.g. https://github.com/tomwhite/cubed/actions/runs/6820474263):

```
FAILED cubed/tests/runtime/test_modal_async.py::test_stragglers[timing_map0-10-2-expected_invocation_counts_overrides0] - FileNotFoundError: ['cubed-unittest/map_unordered']
FAILED cubed/tests/runtime/test_modal_async.py::test_batch - modal.exception.DeprecationError: Deprecated on 2023-08-16: `f.call(...)` is deprecated. It has been renamed to `f.remote(...)`
```