### PR TITLE
Disable the Hypthosis deadline when running Array API tests.

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -109,4 +109,4 @@ jobs:
 
           EOF
 
-          pytest -v -rxXfEA --max-examples=2 --disable-data-dependent-shapes --disable-extension linalg --ci --cov=cubed.array_api --cov-report=term-missing
+          pytest -v -rxXfEA --max-examples=2 --disable-data-dependent-shapes --disable-extension linalg --ci --hypothesis-disable-deadline --cov=cubed.array_api --cov-report=term-missing


### PR DESCRIPTION
The change in https://github.com/data-apis/array-api-tests/pull/207 fixed a bug where Hypothesis deadlines were always disabled.