### PR TITLE
Change the DAG to have separate nodes for operations and arrays

### DIFF
--- a/cubed/runtime/pipeline.py
+++ b/cubed/runtime/pipeline.py
@@ -5,21 +5,32 @@ import networkx as nx
 from cubed.storage.zarr import open_if_lazy_zarr_array
 
 
-def already_computed(node_dict: Dict[str, Any], resume: Optional[bool] = None) -> bool:
+def already_computed(
+    name, dag, nodes: Dict[str, Any], resume: Optional[bool] = None
+) -> bool:
     """
     Return True if the array for a node doesn't have a pipeline to compute it,
-    or it has already been computed (all chunks are present).
+    or if all its outputs have already been computed (all chunks are present).
     """
-    pipeline = node_dict.get("pipeline", None)
+    pipeline = nodes[name].get("pipeline", None)
     if pipeline is None:
         return True
 
-    target = node_dict.get("target", None)
-    if resume and target is not None:
-        target = open_if_lazy_zarr_array(target)
-        # this check can be expensive since it has to list the directory to find nchunks_initialized
-        if target.ndim > 0 and target.nchunks_initialized == target.nchunks:
-            return True
+    # if no outputs have targets then need to compute (this is the create-arrays case)
+    if all(
+        [nodes[output].get("target", None) is None for output in dag.successors(name)]
+    ):
+        return False
+
+    if resume:
+        for output in dag.successors(name):
+            target = nodes[output].get("target", None)
+            if target is not None:
+                target = open_if_lazy_zarr_array(target)
+                # this check can be expensive since it has to list the directory to find nchunks_initialized
+                if target.ndim == 0 or target.nchunks_initialized != target.nchunks:
+                    return False
+        return True
 
     return False
 
@@ -28,7 +39,7 @@ def visit_nodes(dag, resume=None):
     """Return a generator that visits the nodes in the DAG in topological order."""
     nodes = {n: d for (n, d) in dag.nodes(data=True)}
     for name in list(nx.topological_sort(dag)):
-        if already_computed(nodes[name], resume=resume):
+        if already_computed(name, dag, nodes, resume=resume):
             continue
         yield name, nodes[name]
 
@@ -40,7 +51,7 @@ def visit_node_generations(dag, resume=None):
         gen = [
             (name, nodes[name])
             for name in names
-            if not already_computed(nodes[name], resume=resume)
+            if not already_computed(name, dag, nodes, resume=resume)
         ]
         if len(gen) > 0:
             yield gen

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -323,7 +323,9 @@ def test_reduction_multiple_rounds(tmp_path, executor):
     b = xp.sum(a, axis=0, dtype=np.uint8)
     # check that there is > 1 blockwise step (after optimization)
     blockwises = [
-        n for (n, d) in b.plan.dag.nodes(data=True) if d["op_name"] == "blockwise"
+        n
+        for (n, d) in b.plan.dag.nodes(data=True)
+        if d.get("op_name", None) == "blockwise"
     ]
     assert len(blockwises) > 1
     assert b.plan.max_projected_mem() <= 1000


### PR DESCRIPTION
Currently there is a one-to-one correspondence between operations and arrays: one operation produces one array, and is represented by one node in the DAG.

However, this won't be true when we support multiple outputs (#69) where one operation can produce multiple arrays.

Similarly, it also won't support optimizations like sibling fusion (in [Apache Beam](https://beam.apache.org/releases/javadoc/2.0.0/org/apache/beam/sdk/transforms/ParDo.html), and from [FlumeJava](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/35650.pdf) originally), where operations that have the same inputs and produce different outputs can be fused into one operation producing multiple outputs. ([Wukong](https://github.com/ds2-lab/Wukong) calls this "task clustering".)

So we need to change the DAG representation so that one operation can produce multiple arrays, and this means breaking  nodes into two types: operations and arrays.

This PR does exactly that. An example DAG (from `test_add_with_broadcast`) in the current representation

![cubed](https://github.com/tomwhite/cubed/assets/85085/40f78b62-38b0-4428-9399-170afc70d8c2)

now looks like this:

![cubed-new-dag](https://github.com/tomwhite/cubed/assets/85085/eb435aaf-0d60-42a4-ba94-e9293831119b)

Note:
* Operations are shown as boxes with rounded corners, arrays are rectangles.
* Colours indicate the following: pink for a blockwise operation, green for a rechunk operation, orange for a materialized array, white for an operation that is not run in its own pipeline or for an array that is not materialized to disk as a Zarr array ("virtual arrays")

I wondered about having an option to visualize DAGs as we currently do, but that won't work when there are multiple outputs, so it may be best just to have the more general representation. 