### PR TITLE
Introduce `finalize_dag` method in `Plan` that caches DAG optimization

### DIFF
--- a/cubed/core/plan.py
+++ b/cubed/core/plan.py
@@ -157,7 +157,8 @@ class Plan:
     @lru_cache
     def _finalize_dag(self, optimize_graph: bool = True) -> nx.MultiDiGraph:
         dag = self.optimize().dag if optimize_graph else self.dag.copy()
-        return self._create_lazy_zarr_arrays(dag)
+        dag = self._create_lazy_zarr_arrays(dag)
+        return nx.freeze(dag)
 
     def execute(
         self,
@@ -211,6 +212,7 @@ class Plan:
         self, filename="cubed", format=None, rankdir="TB", optimize_graph=True
     ):
         dag = self._finalize_dag(optimize_graph=optimize_graph)
+        dag = dag.copy()  # make a copy since we mutate the DAG below
 
         # remove edges from create-arrays node to avoid cluttering the diagram
         dag.remove_edges_from(list(dag.out_edges("create-arrays")))

--- a/cubed/tests/test_optimization.py
+++ b/cubed/tests/test_optimization.py
@@ -19,8 +19,10 @@ def test_fusion(spec):
     d = xp.negative(c)
 
     num_created_arrays = 4  # a, b, c, d
+    assert d.plan.num_arrays(optimize_graph=False) == num_created_arrays
     assert d.plan.num_tasks(optimize_graph=False) == num_created_arrays + 12
     num_created_arrays = 2  # a, d
+    assert d.plan.num_arrays(optimize_graph=True) == num_created_arrays
     assert d.plan.num_tasks(optimize_graph=True) == num_created_arrays + 4
 
     task_counter = TaskCounter()


### PR DESCRIPTION
Fixes #328

This is a better fix for #328 than #338 that removes duplication, and (like #338) reduces the number of `optimize` and `create_lazy_zarr_arrays` calls from 12 to 4 in `test_visualize`.