### PR TITLE
Handle the case where an array is created by calling `map_blocks` with no input arrays

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -457,9 +457,24 @@ def _target_chunk_selection(target_chunks, idx, selection):
 
 
 def map_blocks(
-    func, *args: "Array", dtype=None, chunks=None, drop_axis=[], new_axis=None, **kwargs
+    func,
+    *args: "Array",
+    dtype=None,
+    chunks=None,
+    drop_axis=[],
+    new_axis=None,
+    spec=None,
+    **kwargs,
 ) -> "Array":
     """Apply a function to corresponding blocks from multiple input arrays."""
+
+    # Handle the case where an array is created by calling `map_blocks` with no input arrays
+    if len(args) == 0:
+        from cubed.array_api.creation_functions import empty_virtual_array
+
+        shape = tuple(map(sum, chunks))
+        args = (empty_virtual_array(shape, dtype=dtype, chunks=chunks, spec=spec),)
+
     if has_keyword(func, "block_id"):
         from cubed.array_api.creation_functions import offsets_virtual_array
 

--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -62,21 +62,19 @@ def from_array(x, chunks="auto", asarray=None, spec=None) -> "Array":
     if asarray is None:
         asarray = not hasattr(x, "__array_function__")
 
-    return map_direct(
+    return map_blocks(
         _from_array,
-        x,
-        shape=x.shape,
         dtype=x.dtype,
         chunks=outchunks,
-        extra_projected_mem=0,
         spec=spec,
+        input_array=x,
         outchunks=outchunks,
         asarray=asarray,
     )
 
 
-def _from_array(e, x, outchunks=None, asarray=None, block_id=None):
-    out = x[get_item(outchunks, block_id)]
+def _from_array(block, input_array, outchunks=None, asarray=None, block_id=None):
+    out = input_array[get_item(outchunks, block_id)]
     if asarray:
         out = np.asarray(out)
     out = numpy_array_to_backend_array(out)

--- a/cubed/tests/test_core.py
+++ b/cubed/tests/test_core.py
@@ -191,6 +191,19 @@ def test_map_blocks_with_block_id(spec, executor):
     )
 
 
+def test_map_blocks_no_array_args(spec, executor):
+    def func(block, block_id=None):
+        return nxp.ones_like(block) * int(sum(block_id))
+
+    a = cubed.map_blocks(func, dtype="int64", chunks=((5, 3),), spec=spec)
+    assert a.chunks == ((5, 3),)
+
+    assert_array_equal(
+        a.compute(executor=executor),
+        np.array([0, 0, 0, 0, 0, 1, 1, 1], dtype="int64"),
+    )
+
+
 def test_map_blocks_with_different_block_shapes(spec):
     def func(x, y):
         return x


### PR DESCRIPTION
This simplifies a lot of the creation functions.