### PR TITLE
Refactor pipeline to reduce coupling between runtime and primitive layers

### DIFF
--- a/cubed/core/ops.py
+++ b/cubed/core/ops.py
@@ -266,7 +266,7 @@ def blockwise(
     spec = check_array_specs(arrays)
     if target_store is None:
         target_store = new_temp_path(name=name, spec=spec)
-    pipeline = primitive_blockwise(
+    op = primitive_blockwise(
         func,
         out_ind,
         *zargs,
@@ -286,14 +286,14 @@ def blockwise(
     plan = Plan._new(
         name,
         "blockwise",
-        pipeline.target_array,
-        pipeline,
+        op.target_array,
+        op,
         False,
         *source_arrays,
     )
     from cubed.array_api import Array
 
-    return Array(name, pipeline.target_array, spec, plan)
+    return Array(name, op.target_array, spec, plan)
 
 
 def general_blockwise(
@@ -322,7 +322,7 @@ def general_blockwise(
     spec = check_array_specs(arrays)
     if target_store is None:
         target_store = new_temp_path(name=name, spec=spec)
-    pipeline = primitive_general_blockwise(
+    op = primitive_general_blockwise(
         func,
         block_function,
         *zargs,
@@ -340,14 +340,14 @@ def general_blockwise(
     plan = Plan._new(
         name,
         "blockwise",
-        pipeline.target_array,
-        pipeline,
+        op.target_array,
+        op,
         False,
         *source_arrays,
     )
     from cubed.array_api import Array
 
-    return Array(name, pipeline.target_array, spec, plan)
+    return Array(name, op.target_array, spec, plan)
 
 
 def elemwise(func, *args: "Array", dtype=None) -> "Array":
@@ -706,7 +706,7 @@ def rechunk(x, chunks, target_store=None):
         target_store = new_temp_path(name=name, spec=spec)
     name_int = f"{name}-int"
     temp_store = new_temp_path(name=name_int, spec=spec)
-    pipelines = primitive_rechunk(
+    ops = primitive_rechunk(
         x.zarray_maybe_lazy,
         target_chunks=target_chunks,
         allowed_mem=spec.allowed_mem,
@@ -717,40 +717,40 @@ def rechunk(x, chunks, target_store=None):
 
     from cubed.array_api import Array
 
-    if len(pipelines) == 1:
-        pipeline = pipelines[0]
+    if len(ops) == 1:
+        op = ops[0]
         plan = Plan._new(
             name,
             "rechunk",
-            pipeline.target_array,
-            pipeline,
+            op.target_array,
+            op,
             False,
             x,
         )
-        return Array(name, pipeline.target_array, spec, plan)
+        return Array(name, op.target_array, spec, plan)
 
     else:
-        pipeline1 = pipelines[0]
+        op1 = ops[0]
         plan1 = Plan._new(
             name_int,
             "rechunk",
-            pipeline1.target_array,
-            pipeline1,
+            op1.target_array,
+            op1,
             False,
             x,
         )
-        x_int = Array(name_int, pipeline1.target_array, spec, plan1)
+        x_int = Array(name_int, op1.target_array, spec, plan1)
 
-        pipeline2 = pipelines[1]
+        op2 = ops[1]
         plan2 = Plan._new(
             name,
             "rechunk",
-            pipeline2.target_array,
-            pipeline2,
+            op2.target_array,
+            op2,
             False,
             x_int,
         )
-        return Array(name, pipeline2.target_array, spec, plan2)
+        return Array(name, op2.target_array, spec, plan2)
 
 
 def merge_chunks(x, chunks):

--- a/cubed/extensions/history.py
+++ b/cubed/extensions/history.py
@@ -12,14 +12,14 @@ class HistoryCallback(Callback):
     def on_compute_start(self, dag, resume):
         plan = []
         for name, node in visit_nodes(dag, resume):
-            pipeline = node["pipeline"]
+            primitive_op = node["primitive_op"]
             plan.append(
                 dict(
                     array_name=name,
                     op_name=node["op_name"],
-                    projected_mem=pipeline.projected_mem,
-                    reserved_mem=pipeline.reserved_mem,
-                    num_tasks=pipeline.num_tasks,
+                    projected_mem=primitive_op.projected_mem,
+                    reserved_mem=primitive_op.reserved_mem,
+                    num_tasks=primitive_op.num_tasks,
                 )
             )
 

--- a/cubed/extensions/tqdm.py
+++ b/cubed/extensions/tqdm.py
@@ -20,7 +20,7 @@ class TqdmProgressBar(Callback):
         self.pbars = {}
         i = 0
         for name, node in visit_nodes(dag, resume):
-            num_tasks = node["pipeline"].num_tasks
+            num_tasks = node["primitive_op"].num_tasks
             self.pbars[name] = tqdm(
                 *self.args, desc=name, total=num_tasks, position=i, **self.kwargs
             )

--- a/cubed/primitive/types.py
+++ b/cubed/primitive/types.py
@@ -1,9 +1,23 @@
 from dataclasses import dataclass
+from typing import Any, Optional
 
 import zarr
 
+from cubed.runtime.types import CubedPipeline
 from cubed.storage.zarr import T_ZarrArray, open_if_lazy_zarr_array
 from cubed.types import T_RegularChunks
+
+
+@dataclass(frozen=True)
+class PrimitiveOperation:
+    """Encapsulates metadata about a ``blockwise`` or ``rechunk`` primitive operation."""
+
+    pipeline: CubedPipeline
+    target_array: Any
+    projected_mem: int
+    reserved_mem: int
+    num_tasks: int
+    write_chunks: Optional[T_RegularChunks] = None
 
 
 class CubedArrayProxy:

--- a/cubed/runtime/types.py
+++ b/cubed/runtime/types.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional
+from typing import Iterable, Optional
 
 from networkx import MultiDiGraph
 
-from cubed.types import T_RegularChunks
 from cubed.vendor.rechunker.types import Config, StageFunction
 
 
@@ -23,11 +22,6 @@ class CubedPipeline:
     name: str
     mappable: Iterable
     config: Config
-    target_array: Any
-    projected_mem: int
-    reserved_mem: int
-    num_tasks: int
-    write_chunks: Optional[T_RegularChunks]
 
 
 class Callback:

--- a/cubed/tests/primitive/test_rechunk.py
+++ b/cubed/tests/primitive/test_rechunk.py
@@ -63,7 +63,7 @@ def test_rechunk(
     target_store = tmp_path / "target.zarr"
     temp_store = tmp_path / "temp.zarr"
 
-    pipelines = rechunk(
+    ops = rechunk(
         source,
         target_chunks=target_chunks,
         allowed_mem=allowed_mem,
@@ -72,25 +72,25 @@ def test_rechunk(
         temp_store=temp_store,
     )
 
-    assert len(pipelines) == len(expected_num_tasks)
+    assert len(ops) == len(expected_num_tasks)
 
-    for i, pipeline in enumerate(pipelines):
-        assert pipeline.target_array.shape == shape
-        assert pipeline.target_array.dtype == source.dtype
+    for i, op in enumerate(ops):
+        assert op.target_array.shape == shape
+        assert op.target_array.dtype == source.dtype
 
-        assert pipeline.projected_mem == expected_projected_mem
+        assert op.projected_mem == expected_projected_mem
 
-        assert pipeline.num_tasks == expected_num_tasks[i]
+        assert op.num_tasks == expected_num_tasks[i]
 
-    last_pipeline = pipelines[-1]
-    assert last_pipeline.target_array.chunks == target_chunks
+    last_op = ops[-1]
+    assert last_op.target_array.chunks == target_chunks
 
     # create lazy zarr arrays
-    for pipeline in pipelines:
-        pipeline.target_array.create()
+    for op in ops:
+        op.target_array.create()
 
-    for pipeline in pipelines:
-        execute_pipeline(pipeline, executor=executor)
+    for op in ops:
+        execute_pipeline(op.pipeline, executor=executor)
 
     res = zarr.open_array(target_store)
     assert_array_equal(res[:], np.ones(shape))


### PR DESCRIPTION
This change makes a separation between the pipeline (run by the runtime layer) and the primitive operation (blockwise or rechunk) that may have extra information that the runtime doesn't care about (e.g. target array). With this change there is no need to update the runtime when new information is added that only blockwise or rechunk needs.