### PR TITLE
Use Dask's 'broadcast trick' to save memory for single-valued arrays

### DIFF
--- a/cubed/storage/virtual.py
+++ b/cubed/storage/virtual.py
@@ -8,7 +8,7 @@ from zarr.indexing import BasicIndexer, is_slice
 from cubed.backend_array_api import namespace as nxp
 from cubed.backend_array_api import numpy_array_to_backend_array
 from cubed.types import T_DType, T_RegularChunks, T_Shape
-from cubed.utils import memory_repr
+from cubed.utils import broadcast_trick, memory_repr
 
 
 class VirtualEmptyArray:
@@ -33,7 +33,8 @@ class VirtualEmptyArray:
         if not isinstance(key, tuple):
             key = (key,)
         indexer = BasicIndexer(key, self.template)
-        return nxp.empty(indexer.shape, dtype=self.dtype)
+        # use broadcast trick so array chunks only occupy a single value in memory
+        return broadcast_trick(nxp.empty)(indexer.shape, dtype=self.dtype)
 
     @property
     def oindex(self):
@@ -68,7 +69,10 @@ class VirtualFullArray:
         if not isinstance(key, tuple):
             key = (key,)
         indexer = BasicIndexer(key, self.template)
-        return nxp.full(indexer.shape, fill_value=self.fill_value, dtype=self.dtype)
+        # use broadcast trick so array chunks only occupy a single value in memory
+        return broadcast_trick(nxp.full)(
+            indexer.shape, fill_value=self.fill_value, dtype=self.dtype
+        )
 
     @property
     def oindex(self):

--- a/cubed/tests/test_utils.py
+++ b/cubed/tests/test_utils.py
@@ -4,9 +4,12 @@ import platform
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
+from cubed.backend_array_api import namespace as nxp
 from cubed.utils import (
     block_id_to_offset,
+    broadcast_trick,
     chunk_memory,
     extract_stack_summaries,
     join_path,
@@ -153,3 +156,16 @@ def test_map_nested_iterators():
     assert count == 2
     assert list(out1) == [4, 5]
     assert count == 4
+
+
+def test_broadcast_trick():
+    a = nxp.ones((10, 10), dtype=nxp.int8)
+    b = broadcast_trick(nxp.ones)((10, 10), dtype=nxp.int8)
+
+    assert_array_equal(a, b)
+    assert a.nbytes == 100
+    assert b.base.nbytes == 1
+
+    a = nxp.ones((), dtype=nxp.int8)
+    b = broadcast_trick(nxp.ones)((), dtype=nxp.int8)
+    assert_array_equal(a, b)


### PR DESCRIPTION
This implements the suggestion in https://github.com/tomwhite/cubed/pull/336#issuecomment-1863096019