### PR TITLE
Implement `partial_reduce` and `tree_reduce` using generalized blockwise

### DIFF
--- a/cubed/array_api/statistical_functions.py
+++ b/cubed/array_api/statistical_functions.py
@@ -25,7 +25,7 @@ def max(x, /, *, axis=None, keepdims=False):
     return reduction(x, nxp.max, axis=axis, dtype=x.dtype, keepdims=keepdims)
 
 
-def mean(x, /, *, axis=None, keepdims=False):
+def mean(x, /, *, axis=None, keepdims=False, use_new_impl=False):
     if x.dtype not in _real_floating_dtypes:
         raise TypeError("Only real floating-point dtypes are allowed in mean")
     # This implementation uses NumPy and Zarr's structured arrays to store a
@@ -46,6 +46,7 @@ def mean(x, /, *, axis=None, keepdims=False):
         intermediate_dtype=intermediate_dtype,
         dtype=dtype,
         keepdims=keepdims,
+        use_new_impl=use_new_impl,
         extra_func_kwargs=extra_func_kwargs,
     )
 
@@ -64,7 +65,7 @@ def _mean_combine(a, **kwargs):
     return {"n": n, "total": total}
 
 
-def _mean_aggregate(a):
+def _mean_aggregate(a, **kwargs):
     return nxp.divide(a["total"], a["n"])
 
 

--- a/cubed/tests/test_array_api.py
+++ b/cubed/tests/test_array_api.py
@@ -551,11 +551,12 @@ def test_argmin_axis_0(spec):
 # Statistical functions
 
 
-def test_mean_axis_0(spec, executor):
+@pytest.mark.parametrize("use_new_impl", [False, True])
+def test_mean_axis_0(spec, executor, use_new_impl):
     a = xp.asarray(
         [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], chunks=(2, 2), spec=spec
     )
-    b = xp.mean(a, axis=0)
+    b = xp.mean(a, axis=0, use_new_impl=use_new_impl)
     assert_array_equal(
         b.compute(executor=executor),
         np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]).mean(axis=0),

--- a/cubed/tests/test_mem_utilization.py
+++ b/cubed/tests/test_mem_utilization.py
@@ -3,11 +3,14 @@ import shutil
 
 import pytest
 
+from cubed.core.ops import partial_reduce
+
 pytest.importorskip("lithops")
 
 import cubed
 import cubed.array_api as xp
 import cubed.random
+from cubed.backend_array_api import namespace as nxp
 from cubed.extensions.history import HistoryCallback
 from cubed.runtime.executors.lithops import LithopsDagExecutor
 from cubed.tests.utils import LITHOPS_LOCAL_CONFIG
@@ -203,6 +206,15 @@ def test_mean(tmp_path, spec):
     )  # 200MB chunks
     b = xp.mean(a, axis=0)
     run_operation(tmp_path, "mean", b)
+
+
+@pytest.mark.slow
+def test_sum_partial_reduce(tmp_path, spec):
+    a = cubed.random.random(
+        (40000, 10000), chunks=(5000, 5000), spec=spec
+    )  # 200MB chunks
+    b = partial_reduce(a, nxp.sum, split_every={0: 8})
+    run_operation(tmp_path, "sum_partial_reduce", b)
 
 
 # Internal functions


### PR DESCRIPTION
The new implementation is hidden behind a flag (`use_new_impl`) to make it easier to compare the old and new code.